### PR TITLE
Root folder edit uses dropdown + fix inconsistencies

### DIFF
--- a/app/common/selectable.ts
+++ b/app/common/selectable.ts
@@ -75,12 +75,21 @@ class SelectableService {
 })
 export class ItemMarker {
     private _model: any;
+    private _isAttached: any = null;
 
     constructor(@Optional() private _svc: SelectableService) {
     }
 
     public setModel(model: any) {
         this._model = model;
+    }
+
+    public get isAttached(): any {
+        return this._isAttached;
+    }
+
+    public set isAttached(value: any) {
+        this._isAttached = value;
     }
 
     public get isSelected(): boolean {
@@ -100,6 +109,7 @@ export class SelectableListItem implements OnInit, OnDestroy {
     @Input() public model: any;
 
     private _tearDown: Function;
+    private _isAttached: boolean;
 
     constructor(private _host: ElementRef,
                 private _renderer: Renderer,
@@ -112,7 +122,18 @@ export class SelectableListItem implements OnInit, OnDestroy {
     }
 
     public ngOnInit() {
-        this.setModel(this.model);
+
+        if (this._listItem && !this._listItem.isAttached) {
+
+            //
+            // Prevent binding to children [model] directives after initial binding
+
+            this._isAttached = true;
+
+            this._listItem.isAttached = true;
+
+            this.setModel(this.model);
+        }
     }
 
     public ngOnChanges(changes: { [key: string]: SimpleChange; }): any {
@@ -122,13 +143,15 @@ export class SelectableListItem implements OnInit, OnDestroy {
     }
 
     public ngOnDestroy() {
+        this._listItem = null;
+
         if (this._tearDown) {
             this._tearDown();
         }
     }
 
     private setModel(model: any) {
-        if (this._listItem) {
+        if (this._listItem && this._isAttached) {
             this._listItem.setModel(model);
         }
     }

--- a/app/common/selectable.ts
+++ b/app/common/selectable.ts
@@ -192,6 +192,15 @@ export class Selectable implements OnInit {
     }
 
     private selectAll(event: Event) {
+
+        //
+        // Prevent selecting all when prevent is requested
+        // Or when the user is trying to select all text in an input
+
+        if (event.defaultPrevented || (<HTMLElement>event.target).tagName == "INPUT") {
+            return;
+        }
+
         this._svc.selectAll(event);
         this._changeDetectorRef.markForCheck();
     }

--- a/app/files/edit-location.component.ts
+++ b/app/files/edit-location.component.ts
@@ -6,11 +6,7 @@ import { Location } from './location';
 @Component({
     selector: 'edit-location',
     template: `
-        <div class="background-editing">
-            <div class="actions">
-                <button title="OK" class="ok" (click)="onOk()"></button>
-                <button title="Cancel" class="cancel" (click)="cancel.next()"></button>
-            </div>
+        <div>
             <fieldset class="name">
                 <label>Alias</label>
                 <input [(ngModel)]="model.alias" class="form-control" type="text" autofocus>
@@ -26,13 +22,12 @@ import { Location } from './location';
                     <checkbox2 [(model)]="_write">Write</checkbox2>
                 </div>
             </fieldset>
+            <p class="pull-right">
+                <button class="ok" (click)="onOk()">{{model.id ? 'OK' : 'Create'}}</button>
+                <button class="cancel" (click)="cancel.next()">Cancel</button>
+            </p>
         </div>
-    `,
-    styles: [`
-        .background-editing {
-            padding: 5px 15px;
-        }
-    `]
+    `
 })
 export class LocationEditComponent implements OnInit {
 

--- a/app/files/file-explorer.ts
+++ b/app/files/file-explorer.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, Input, Inject, ViewChild } from '@angular/core';
 
 import { Subscription } from 'rxjs/Subscription';
 
-import { ApiFile, ApiFileType } from './file';
+import { ApiFile, ApiFileType, ExplorerOptions } from './file';
 import { FileListComponent } from './file-list';
 import { FilesService } from './files.service';
 import { FileNavService } from './file-nav.service';
@@ -13,12 +13,12 @@ import { FileNavService } from './file-nav.service';
         <file-selector #fileSelector class="right" (selected)="upload($event)" [multiple]="true">
         </file-selector>
         <toolbar
-            [refresh]="true"
-            [newFile]="!atRoot()"
-            [newLocation]="showNewLocation()"
-            [newFolder]="showNewFolder()"
-            [upload]="!atRoot()"
-            [delete]="selected && selected.length > 0"
+            [refresh]="options.EnableRefresh || null"
+            [newFile]="(options.EnableNewFile || null) && !atRoot()"
+            [newLocation]="(options.EnableNewFolder || null) && showNewLocation()"
+            [newFolder]="(options.EnableNewFolder || null) && showNewFolder()"
+            [upload]="(options.EnableUpload || null) && !atRoot()"
+            [delete]="(options.EnableDelete || null) && selected && selected.length > 0"
             (onNewLocation)="createLocation()"
             (onRefresh)="refresh()"
             (onNewFolder)="createDirectory()"
@@ -40,6 +40,7 @@ export class FileExplorer implements OnDestroy {
     private _subscriptions: Array<Subscription> = [];
     @ViewChild(FileListComponent) private _list: FileListComponent;
 
+    @Input() public options: ExplorerOptions = new ExplorerOptions(true);
     @Input() public types: Array<string> = [];
 
     constructor(@Inject("FilesService") private _svc: FilesService,

--- a/app/files/file-explorer.ts
+++ b/app/files/file-explorer.ts
@@ -15,8 +15,8 @@ import { FileNavService } from './file-nav.service';
         <toolbar
             [refresh]="true"
             [newFile]="!atRoot()"
-            [newLocation]="atRoot() || null"
-            [newFolder]="!atRoot() || null"
+            [newLocation]="showNewLocation()"
+            [newFolder]="showNewFolder()"
             [upload]="!atRoot()"
             [delete]="selected && selected.length > 0"
             (onNewLocation)="createLocation()"
@@ -87,5 +87,29 @@ export class FileExplorer implements OnDestroy {
 
     private atRoot(): boolean {
         return !!(this._current && !this._current.physical_path);
+    }
+
+    private showNewLocation() {
+
+        //
+        // If the list is being used to create a folder/dir hide the button
+
+        if (!(this._list && !this._list.creating)) {
+            return null;
+        }
+
+        return this.atRoot() || null;
+    }
+
+    private showNewFolder() {
+
+        //
+        // If the list is being used to create a folder/dir disable the button
+
+        if (!(this._list && !this._list.creating)) {
+            return false;
+        }
+
+        return !this.atRoot() || null;
     }
 }

--- a/app/files/file-explorer.ts
+++ b/app/files/file-explorer.ts
@@ -24,7 +24,7 @@ import { FileNavService } from './file-nav.service';
             (onNewFolder)="createDirectory()"
             (onNewFile)="createFile()"
             (onUpload)="fileSelector.open()"
-            (onDelete)="deleteFiles(selected)"></toolbar>
+            (onDelete)="deleteFiles($event, selected)"></toolbar>
         <navigation></navigation>
         <file-list *ngIf="isDir(_current)" [types]="types"></file-list>
     `,
@@ -73,8 +73,8 @@ export class FileExplorer implements OnDestroy {
         this._list.createFile();
     }
 
-    private deleteFiles(files: Array<ApiFile>) {
-        this._list.deleteFiles(files);
+    private deleteFiles(event: Event, files: Array<ApiFile>) {
+        this._list.deleteFiles(event, files);
     }
 
     private upload(files: Array<File>) {

--- a/app/files/file-icons.css
+++ b/app/files/file-icons.css
@@ -37,6 +37,9 @@
 
 .fi.directory i::before {
     content: "\f07b";
+}
+
+.fi.directory:not([disabled]) i::before {
     color: #FFE68E;
 }
 

--- a/app/files/file-list-item.ts
+++ b/app/files/file-list-item.ts
@@ -20,6 +20,7 @@ import { ApiFile, ApiFileType } from './file';
                     <input class="form-control inline-block" type="text" 
                            [ngModel]="model.name"
                            (ngModelChange)="rename($event)"
+                           (blur)="onBlur($event)"
                            (keyup.enter)="_editing=false"
                            (keyup.esc)="onCancel($event)"
                            (keyup.delete)="$event.stopImmediatePropagation()"
@@ -137,6 +138,15 @@ export class FileComponent {
             })
     }
 
+    private onBlur(event: Event) {
+        if (event && event.target && (<HTMLInputElement>event.target).value === this.model.name) {
+
+            //
+            // No change. Force cancel
+            this.cancel();
+        }
+    }
+
     private onCancel(e: Event) {
         e.preventDefault();
 
@@ -172,7 +182,7 @@ export class FileComponent {
 
     private cancel() {
         this._editing = false;
-        this._location = false;
+        this._location = null;
     }
 
     private onClickName(e: Event) {

--- a/app/files/file-list-item.ts
+++ b/app/files/file-list-item.ts
@@ -52,7 +52,7 @@ import { ApiFile, ApiFileType } from './file';
                 </div>
             </div>
         </div>
-        <edit-location *ngIf="_location && _editing" [model]="_location" (cancel)="cancel()" (dblclick)="prevent($event)"></edit-location>
+        <edit-location *ngIf="_location && _editing" [model]="_location" (cancel)="cancel()" (dblclick)="prevent($event)" (keyup.delete)="prevent($event)"></edit-location>
     `,
     styles: [`
         a {

--- a/app/files/file-list-item.ts
+++ b/app/files/file-list-item.ts
@@ -1,6 +1,5 @@
 import { Component, Input, Output, Inject, ViewChild, EventEmitter } from '@angular/core';
 
-import { Selector } from '../common/selector';
 import { NotificationService } from '../notification/notification.service';
 import { Humanizer } from '../common/primitives';
 
@@ -11,12 +10,12 @@ import { ApiFile, ApiFileType } from './file';
 @Component({
     selector: 'file',
     template: `
-        <div *ngIf="model && !(_editing && _location)" class="grid-item row" [class.background-editing]="_editing" (keyup.f2)="onRename($event)" tabindex="-1">
+        <div *ngIf="model" class="grid-item row" [class.background-editing]="_editing && !_location" [class.background-selected]="_editing && _location" (keyup.f2)="onRename($event)" tabindex="-1">
             <div class="col-xs-9 col-sm-5 col-lg-4 fi" [ngClass]="[model.type, model.extension, (isRoot ? 'location' : '')]">
-                <div *ngIf="!_editing">
+                <div *ngIf="!_editing || _location">
                     <a class="color-normal hover-color-active" [href]="href" nofocus (click)="onClickName($event)"><i></i>{{model.alias || model.name}}</a>
                 </div>
-                <div *ngIf="_editing">
+                <div *ngIf="_editing && !_location">
                     <i></i>
                     <input class="form-control inline-block" type="text" 
                            [ngModel]="model.name"
@@ -36,23 +35,25 @@ import { ApiFile, ApiFileType } from './file';
                 <span *ngIf="model.size">{{getSize()}}</span>
             </div>
             <div class="actions">
-                <div class="selector-wrapper">
-                    <button title="More" (click)="openSelector($event)" (dblclick)="prevent($event)" [class.background-active]="(selector && selector.opened) || false">
+                <div class="action-selector">
+                    <button title="More" (click)="selector.toggle()" (dblclick)="prevent($event)" [class.background-active]="(selector && selector.opened) || false">
                         <i class="fa fa-ellipsis-h"></i>
                     </button>
-                    <selector [right]="true">
+                    <selector #selector [right]="true">
                         <ul>
-                            <li><button *ngIf="!isRoot" class="edit" title="Rename" (click)="onRename($event)">Rename</button></li>
-                            <li><button *ngIf="isRoot" class="edit" title="Edit" (click)="onEdit($event)">Edit</button></li>
-                            <li><button class="download" title="Download" *ngIf="model.type=='file'" (click)="onDownload($event)">Download</button></li>
-                            <li><button *ngIf="!isRoot" class="delete" title="Delete" (click)="onDelete($event)">Delete</button></li>
-                            <li><button *ngIf="isRoot" class="delete" title="Delete" (click)="onDelete($event)">Remove</button></li>
+                            <li><button *ngIf="!isRoot" #menuButton class="edit" title="Rename" (click)="onRename($event)">Rename</button></li>
+                            <li><button *ngIf="isRoot" #menuButton class="edit" title="Edit" (click)="onEdit($event)">Edit</button></li>
+                            <li><button class="download" #menuButton title="Download" *ngIf="model.type=='file'" (click)="onDownload($event)">Download</button></li>
+                            <li><button *ngIf="!isRoot" #menuButton class="delete" title="Delete" (click)="onDelete($event)">Delete</button></li>
+                            <li><button *ngIf="isRoot" #menuButton class="delete" title="Delete" (click)="onDelete($event)">Remove</button></li>
                         </ul>
                     </selector>
                 </div>
             </div>
         </div>
-        <edit-location *ngIf="_location && _editing" [model]="_location" (cancel)="cancel()" (dblclick)="prevent($event)" (keyup.delete)="prevent($event)"></edit-location>
+        <selector #editSelector [opened]="true" *ngIf="_location && _editing" class="container-fluid" (hide)="cancel()">
+            <edit-location *ngIf="_location && _editing" [model]="_location" (cancel)="cancel()" (dblclick)="prevent($event)" (keyup.delete)="prevent($event)"></edit-location>
+        </selector>
     `,
     styles: [`
         a {
@@ -77,21 +78,6 @@ import { ApiFile, ApiFileType } from './file';
         .row {
             margin: 0px;
         }
-
-        .selector-wrapper {
-            position: relative;
-        }
-
-        selector {
-            position:absolute;
-            right:0;
-            top: 32px;
-        }
-
-        selector button {
-            min-width: 125px;
-            width: 100%;
-        }
     `],
     styleUrls: [
         'app/files/file-icons.css'
@@ -102,8 +88,6 @@ export class FileComponent {
     @Output() modelChanged: EventEmitter<any> = new EventEmitter();
     private _date = null;
     private _location = null;
-
-    @ViewChild(Selector) selector: Selector;
 
     private _editing = false;
 
@@ -138,7 +122,6 @@ export class FileComponent {
 
     private onRename(e: Event) {
         e.preventDefault();
-        this.selector.close();
 
         this._editing = true;
     }
@@ -155,14 +138,12 @@ export class FileComponent {
 
     private onCancel(e: Event) {
         e.preventDefault();
-        this.selector.close();
 
         this.cancel();
     }
 
     private onDelete(e: Event) {
         e.preventDefault();
-        this.selector.close();
 
         let msg = this.model.isLocation ? "Are you sure you want to remove the root folder '" + this.model.name + "'?" :
             "Are you sure you want to delete '" + this.model.name + "'?";
@@ -180,7 +161,6 @@ export class FileComponent {
 
     private onDownload(e: Event) {
         e.preventDefault();
-        this.selector.close();
 
         this._svc.download(this.model);
     }
@@ -190,16 +170,8 @@ export class FileComponent {
     }
 
     private cancel() {
-        if (this.selector) {
-            this.selector.close();
-        }
-
         this._editing = false;
         this._location = false;
-    }
-
-    private openSelector(e: Event) {
-        this.selector.toggle();
     }
 
     private onClickName(e: Event) {

--- a/app/files/file-list-item.ts
+++ b/app/files/file-list-item.ts
@@ -20,8 +20,10 @@ import { ApiFile, ApiFileType } from './file';
                     <input class="form-control inline-block" type="text" 
                            [ngModel]="model.name"
                            (ngModelChange)="rename($event)"
+                           (keyup.enter)="_editing=false"
                            (keyup.esc)="onCancel($event)"
                            (keyup.delete)="$event.stopImmediatePropagation()"
+                           (dblclick)="prevent($event)"
                            required throttle autofocus/>
                 </div>
             </div>
@@ -88,7 +90,6 @@ export class FileComponent {
     @Output() modelChanged: EventEmitter<any> = new EventEmitter();
     private _date = null;
     private _location = null;
-
     private _editing = false;
 
     constructor(@Inject("FilesService") private _svc: FilesService,
@@ -112,7 +113,7 @@ export class FileComponent {
     }
 
     private rename(name: string) {
-        if (this._editing && name) {
+        if (name) {
             this._svc.rename(this.model, name);
             this.modelChanged.emit(this.model);
         }

--- a/app/files/file-list.ts
+++ b/app/files/file-list.ts
@@ -48,9 +48,9 @@ import { FileNavService } from './file-nav.service';
                     <label class="col-md-1 visible-lg visible-md text-right" [ngClass]="_orderBy.css('size')" (click)="sort('size')">Size</label>
                 </div>
             </div>
-            <div class="grid-list container-fluid" *ngIf="_newLocation">
+            <selector #editSelector [opened]="true" *ngIf="_newLocation" class="container-fluid" (hide)="_newLocation=null">
                 <edit-location [model]="_newLocation" (cancel)="_newLocation=null" (save)="onSaveNewLocation()"></edit-location>
-            </div>
+            </selector>
             <div class="grid-list container-fluid" *ngIf="_newDir">
                 <new-file [model]="_newDir" (cancel)="_newDir=null" (save)="onSaveNewDir()"></new-file>
             </div>

--- a/app/files/file-list.ts
+++ b/app/files/file-list.ts
@@ -29,7 +29,7 @@ import { FileNavService } from './file-nav.service';
             [selected]="_selected"
 
             (blur)="onBlur($event)"
-            (keyup.delete)="deleteFiles(_selected)"
+            (keyup.delete)="deleteFiles($event, _selected)"
 
             (drop)="drop($event)"
             (dragover)="dragOver($event)"
@@ -169,10 +169,24 @@ export class FileListComponent implements OnInit, OnDestroy {
     public createLocation() {
         this.clearSelection();
 
+        let alias = "sites"
+        let index = 0;
+
+        //
+        // Avoid new name collision
+
+        while (this._items.length > 0 && 
+                (this._items.find(item => item.isLocation && item.name.toLowerCase() == alias) != null ||
+                 this._items.find(item => item.isLocation && item.alias && item.alias.toLowerCase() == alias) != null))
+        {
+            index++;
+            alias = "sites (" + index + ")";
+        }
+
         let location = new Location();
 
-        location.alias = "sites";
-        location.path = "%systemdrive%\\sites";
+        location.alias = alias;
+        location.path = "%systemdrive%\\" + alias;
 
         location.claims = [
             "read",
@@ -208,7 +222,10 @@ export class FileListComponent implements OnInit, OnDestroy {
         this._newDir = file;
     }
 
-    public deleteFiles(files: Array<ApiFile>) {
+    public deleteFiles(e: Event, files: Array<ApiFile>) {
+        if (e.defaultPrevented) {
+            return;
+        }
 
         if (files && files.length < 1) {
             return;

--- a/app/files/file-list.ts
+++ b/app/files/file-list.ts
@@ -125,6 +125,10 @@ export class FileListComponent implements OnInit, OnDestroy {
                 private _navSvc: FileNavService) {
     }
 
+    public get creating(): boolean {
+        return !!this._newDir || !!this._newLocation;
+    }
+
     public get selected(): Array<ApiFile> {
         return this._selected;
     }
@@ -201,8 +205,17 @@ export class FileListComponent implements OnInit, OnDestroy {
     public createDirectory() {
         this.clearSelection();
 
+        let name = "New Folder";
+        let index = 0;
+
+        while (this._items.length > 0 && this._items.find(item => item.name.toLocaleLowerCase() == name.toLocaleLowerCase()) != null) {
+            index++;
+            name = "New Folder (" + index + ")";
+        }
+
         let dir = new ApiFile();
 
+        dir.name = name;
         dir.parent = this._current;
         dir.type = ApiFileType.Directory;
 
@@ -213,8 +226,17 @@ export class FileListComponent implements OnInit, OnDestroy {
     public createFile() {
         this.clearSelection();
 
+        let name = "new.html";
+        let index = 0;
+
+        while (this._items.length > 0 && this._items.find(item => item.name.toLocaleLowerCase() == name.toLocaleLowerCase()) != null) {
+            index++;
+            name = "new (" + index + ").html";
+        }
+
         let file = new ApiFile();
 
+        file.name = name;
         file.parent = this._current;
         file.type = ApiFileType.File;
 
@@ -312,6 +334,10 @@ export class FileListComponent implements OnInit, OnDestroy {
     }
 
     private onSaveNewDir() {
+        if (!this._newDir) {
+            return;
+        }
+
         let existing = this._items.find(f => f.name == this._newDir.name);
 
         if (!existing) {
@@ -322,6 +348,10 @@ export class FileListComponent implements OnInit, OnDestroy {
     }
 
     private onSaveNewLocation() {
+        if (!this._newLocation) {
+            return;
+        }
+
         let existing = this._items.find(f => f.name == this._newLocation.alias);
 
         if (!existing) {

--- a/app/files/file-selector.component.ts
+++ b/app/files/file-selector.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, Output, EventEmitter, ViewChild } from '@angular/core';
+import { Component, Input, Output, EventEmitter, ViewChild, OnInit } from '@angular/core';
 
 import { Selector } from '../common/selector';
 
-import { ApiFile } from './file';
+import { ApiFile, ExplorerOptions } from './file';
 import { FilesComponent } from './files.component';
 
 
@@ -14,6 +14,7 @@ import { FilesComponent } from './files.component';
                 <file-viewer
                     *ngIf="selector.opened"
                     [types]="types" 
+                    [options]="_explorerOptions"
                     [useHash]="false"></file-viewer>
             </div>
             <p class="pull-right">
@@ -43,13 +44,25 @@ import { FilesComponent } from './files.component';
         }
     `]
 })
-export class FileSelectorComponent {
+export class FileSelectorComponent implements OnInit {
     @Input() public types: Array<string> = [];
     @Input() public multi: boolean = false;
     @Output() public selected: EventEmitter<Array<ApiFile>> = new EventEmitter<Array<ApiFile>>();
 
+    private _explorerOptions: ExplorerOptions;
     @ViewChild(Selector) private _selector: Selector;
     @ViewChild(FilesComponent) private _fileList: FilesComponent;
+
+    constructor() {
+        this._explorerOptions = new ExplorerOptions(false);
+        this._explorerOptions.EnableRefresh = this._explorerOptions.EnableNewFolder = true;
+    }
+
+    public ngOnInit() {
+        if (this.types.find(t => t.toLocaleLowerCase() == 'file')) {
+            this._explorerOptions.EnableNewFile = true;
+        }
+    }
 
     public toggle(): void {
         this._selector.toggle();

--- a/app/files/file.ts
+++ b/app/files/file.ts
@@ -125,3 +125,29 @@ export class FileChangeEvent {
         return evt;
     }
 }
+
+export class ExplorerOptions {
+    public EnableRefresh: boolean;
+    public EnableNewFile: boolean;
+    public EnableNewFolder: boolean;
+    public EnableUpload: boolean;
+    public EnableDelete: boolean;
+
+    private static _allEnabled = new ExplorerOptions(true);
+
+    constructor(initalValue: boolean) {
+        this.setAll(initalValue);
+    }
+
+    public static get AllEnabled() {
+        return this._allEnabled;
+    }
+
+    private setAll(val: boolean) {
+        this.EnableRefresh = val;
+        this.EnableNewFile = val;
+        this.EnableNewFolder = val;
+        this.EnableUpload = val;
+        this.EnableDelete = val;
+    }
+}

--- a/app/files/files.component.ts
+++ b/app/files/files.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy, Input, Inject, ViewChild } from '@angular
 
 import { Subscription } from 'rxjs/Subscription';
 
-import { ApiFile, ApiFileType } from './file';
+import { ApiFile, ApiFileType, ExplorerOptions } from './file';
 import { FilesService } from './files.service';
 import { FileNavService } from './file-nav.service';
 import { NavigationHelper } from './navigation-helper';
@@ -12,7 +12,7 @@ import { FileExplorer } from './file-explorer';
     selector: 'file-viewer',
     template: `
         <file-editor *ngIf="_current && !isDir(_current)" [file]="_current"></file-editor>
-        <file-explorer *ngIf="isDir(_current)" [types]="types"></file-explorer>
+        <file-explorer *ngIf="isDir(_current)" [types]="types" [options]="options"></file-explorer>
     `,
     providers: [
         FileNavService,
@@ -24,6 +24,7 @@ export class FilesComponent implements OnInit, OnDestroy {
     private _subscriptions: Array<Subscription> = [];
     @ViewChild(FileExplorer) private _list: FileExplorer;
 
+    @Input() public options: ExplorerOptions = ExplorerOptions.AllEnabled;
     @Input() public types: Array<string> = [];
     @Input() public useHash: boolean = true;
 

--- a/app/files/new-file.component.ts
+++ b/app/files/new-file.component.ts
@@ -11,10 +11,7 @@ import { ApiFile, ApiFileType } from './file';
         <div class="grid-item row background-editing">
             <div class="col-xs-8 col-sm-5 col-md-5 col-lg-4 col-left fi" [ngClass]="type || (model && model.type)">
                 <i></i>
-                <input [(ngModel)]="model.name" class="form-control inline-block" type="text" (keyup.enter)="onOk()" (keyup.esc)="cancel.next()" autofocus>
-            </div>
-            <div class="actions">
-                <button title="Cancel" class="cancel" (click)="cancel.next()"></button>
+                <input [(ngModel)]="model.name" class="form-control inline-block" type="text" (keyup.enter)="onOk()" (blur)="onOk()" (keyup.esc)="cancel.next()" autofocus>
             </div>
         </div>
     `,

--- a/app/files/toolbar.component.ts
+++ b/app/files/toolbar.component.ts
@@ -6,7 +6,7 @@ import { FormsModule } from '@angular/forms';
     selector: 'toolbar',
     template: `
         <div>
-            <button class="delete" title="Delete" (click)="onDelete.next()" *ngIf="delete !== null" [attr.disabled]="delete === false || null"></button>
+            <button class="delete" title="Delete" (click)="onDelete.next($event)" *ngIf="delete !== null" [attr.disabled]="delete === false || null"></button>
             <button title="Upload" (click)="onUpload.next()" *ngIf="upload !== null" [attr.disabled]="upload === false || null"><i class="fa fa-upload"></i></button>
             <button class="fi text-center directory" title="New Folder" (click)="onNewFolder.next()" *ngIf="newFolder !== null" [attr.disabled]="newFolder === false || null"><i></i></button>
             <button class="fi text-center directory location" title="New Root" (click)="onNewLocation.next()" *ngIf="newLocation !== null" [attr.disabled]="newLocation === false || null"><i class="color-normal"></i></button>

--- a/app/webserver/files/new-webfile.component.ts
+++ b/app/webserver/files/new-webfile.component.ts
@@ -12,12 +12,7 @@ import {WebFileType, WebFile} from './webfile';
     template: `
         <div class="grid-item row background-editing">
             <div class="col-xs-8 col-sm-5 col-md-5 col-lg-4 col-left">
-                <input [(ngModel)]="model.name" class="form-control" type="text" (keyup.enter)="onOk()" (blur)="cancel.next()" (keyup.esc)="cancel.next()" autofocus>
-            </div>
-            <div class="actions">
-                <button title="Cancel" (click)="cancel.next()">
-                    <i class="fa fa-times red"></i>
-                </button>
+                <input [(ngModel)]="model.name" class="form-control" type="text" (keyup.enter)="onOk()" (blur)="onOk()" (keyup.esc)="cancel.next()" autofocus>
             </div>
         </div>
     `,

--- a/app/webserver/files/webfile-explorer.ts
+++ b/app/webserver/files/webfile-explorer.ts
@@ -15,8 +15,8 @@ import { WebSite } from '../websites/site';
         <toolbar
             [newLocation]="null"
             [refresh]="true"
-            [newFile]="!_newDir"
-            [newFolder]="!_newDir"
+            [newFile]="_list && !_list.creating"
+            [newFolder]="_list && !_list.creating"
             [upload]="true"
             [delete]="_list && _list.selected.length > 0"
             (onRefresh)="refresh()"

--- a/app/webserver/files/webfile-list-item.ts
+++ b/app/webserver/files/webfile-list-item.ts
@@ -21,8 +21,11 @@ import { WebFileType, WebFile } from './webfile';
                     <input class="form-control inline-block" type="text" 
                            [ngModel]="model.name"
                            (ngModelChange)="rename($event)"
+                           (blur)="onBlur($event)"
+                           (keyup.enter)="_editing=false"
                            (keyup.esc)="onCancel($event)"
                            (keyup.delete)="$event.stopImmediatePropagation()"
+                           (dblclick)="prevent($event)"
                            required throttle autofocus/>
                 </div>
             </div>
@@ -126,7 +129,7 @@ export class WebFileComponent {
     }
     
     private rename(name: string) {
-        if (this._editing && name) {
+        if (name) {
             this._service.rename(this.model, name);
             this.modelChanged.emit(this.model);
         }
@@ -139,6 +142,15 @@ export class WebFileComponent {
         this.selector.close();
 
         this.cancel();
+    }
+
+    private onBlur(event: Event) {
+        if (event && event.target && (<HTMLInputElement>event.target).value === this.model.name) {
+
+            //
+            // No change. Force cancel
+            this.cancel();
+        }
     }
 
     private onRename(e: Event) {

--- a/app/webserver/files/webfile-list.ts
+++ b/app/webserver/files/webfile-list.ts
@@ -117,6 +117,10 @@ export class WebFileListComponent implements OnInit, OnDestroy {
     constructor(private _svc: WebFilesService) {
     }
 
+    public get creating(): boolean {
+        return !!this._newDir;
+    }
+
     public get selected(): Array<WebFile> {
         return this._selected;
     }
@@ -161,8 +165,17 @@ export class WebFileListComponent implements OnInit, OnDestroy {
     public createDirectory() {
         this.clearSelection();
 
+        let name = "New Folder";
+        let index = 0;
+
+        while (this._items.length > 0 && this._items.find(item => item.name.toLocaleLowerCase() == name.toLocaleLowerCase()) != null) {
+            index++;
+            name = "New Folder (" + index + ")";
+        }
+
         let dir = new WebFile();
 
+        dir.name = name;
         dir.parent = this._current;
         dir.type = WebFileType.Directory;
 
@@ -172,9 +185,17 @@ export class WebFileListComponent implements OnInit, OnDestroy {
 
     public createFile() {
         this.clearSelection();
+        let name = "new.html";
+        let index = 0;
+
+        while (this._items.length > 0 && this._items.find(item => item.name.toLocaleLowerCase() == name.toLocaleLowerCase()) != null) {
+            index++;
+            name = "new (" + index + ").html";
+        }
 
         let file = new WebFile();
 
+        file.name = name;
         file.parent = this._current;
         file.type = WebFileType.File;
 
@@ -252,6 +273,10 @@ export class WebFileListComponent implements OnInit, OnDestroy {
     }
 
     private onSaveNewDir() {
+        if (!this._newDir) {
+            return;
+        }
+
         let existing = this._items.find(f => f.name == this._newDir.name);
 
         if (!existing) {

--- a/app/webserver/url-rewrite/inbound-rules/inbound-rule.component.ts
+++ b/app/webserver/url-rewrite/inbound-rules/inbound-rule.component.ts
@@ -3,7 +3,6 @@
 import { Subscription } from 'rxjs/Subscription';
 
 import { NotificationService } from '../../../notification/notification.service';
-import { Selector } from '../../../common/selector';
 import { UrlRewriteService } from '../service/url-rewrite.service';
 import { InboundRule, ActionTypeHelper } from '../url-rewrite';
 


### PR DESCRIPTION
* The process of editing and creating root folders now uses the drop down edit dialog.

* Certain behaviors such as clicking out of a new folder dialog were inconsistent with modern file explorer design.

* Removed unnecessary buttons from folder selector dialog such as when specifying a web site's physical path.