### PR TITLE
Fixed accessibility issues

### DIFF
--- a/src/app/common/focus.ts
+++ b/src/app/common/focus.ts
@@ -12,8 +12,10 @@ export class AutoFocus {
     }    
 
     ngOnInit() {
-        this._renderer.invokeElementMethod(this._el.nativeElement, 'focus', []);
-
+        setTimeout(() => {
+            this._renderer.invokeElementMethod(this._el.nativeElement, 'focus', []);
+        }, 1);
+        
         if (this._el.nativeElement.select) {
             setTimeout(() => {
                 this._renderer.invokeElementMethod(this._el.nativeElement, 'select', []);

--- a/src/app/common/string-list.component.ts
+++ b/src/app/common/string-list.component.ts
@@ -13,7 +13,14 @@ import { Module as Validators } from './validators';
         <div *ngIf='list.length > 0'>
             <ul class="grid-list container-fluid">
                 <li *ngFor="let item of list; let i = index" class="row border-color grid-item" (dblclick)="onEdit(i)" [class.background-editing]="i === _editing">
-                    <div class="col-xs-12">
+                        <div class="col-xs-6 overflow-visible">
+                            <div>
+                                <span class="form-control" *ngIf="_editing != i">{{item.value}}</span>
+                            </div>
+                            <div *ngIf="_editing == i">
+                                <input  #val='ngModel' autofocus [(ngModel)]="list[i].value" class="form-control" type="text" required [lateBindValidator]="validator" (keyup.enter)="save(i)" [attr.title]="!title ? null : title" />
+                            </div>
+                        </div>
                         <div class="actions">
                             <button [disabled]="shouldDisable(i)" *ngIf="_editing == i" title="Ok" (click)="save(i)">
                                 <i class="fa fa-check color-active"></i>
@@ -28,13 +35,6 @@ import { Module as Validators } from './validators';
                                 <i class="fa fa-trash-o red"></i>
                             </button>
                         </div>
-                        <div>
-                            <span class="form-control" *ngIf="_editing != i">{{item.value}}</span>
-                        </div>
-                        <div *ngIf="_editing == i">
-                            <input  #val='ngModel' autofocus [(ngModel)]="list[i].value" class="form-control" type="text" required [lateBindValidator]="validator" (keyup.enter)="save(i)" [attr.title]="!title ? null : title" />
-                        </div>
-                    </div>
                 </li>
             </ul>
         </div>

--- a/src/app/common/string-list.component.ts
+++ b/src/app/common/string-list.component.ts
@@ -13,11 +13,11 @@ import { Module as Validators } from './validators';
         <div *ngIf='list.length > 0'>
             <ul class="grid-list container-fluid">
                 <li *ngFor="let item of list; let i = index" class="row border-color grid-item" (dblclick)="onEdit(i)" [class.background-editing]="i === _editing">
-                        <div class="col-xs-6 overflow-visible">
-                            <div>
-                                <span class="form-control" *ngIf="_editing != i">{{item.value}}</span>
-                            </div>
-                            <div *ngIf="_editing == i">
+                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6 overflow-visible ">
+                        <div>
+                            <span class="form-control" *ngIf="_editing != i">{{item.value}}</span>
+                        </div>
+                        <div *ngIf="_editing == i">
                                 <input  #val='ngModel' autofocus [(ngModel)]="list[i].value" class="form-control" type="text" required [lateBindValidator]="validator" (keyup.enter)="save(i)" [attr.title]="!title ? null : title" />
                             </div>
                         </div>

--- a/src/app/files/file-list-item.ts
+++ b/src/app/files/file-list-item.ts
@@ -30,7 +30,7 @@ import { ApiFile, ApiFileType } from './file';
             </div>
             <div class="col-sm-3 col-md-2 hidden-xs valign support">
                 <span *ngIf="model.last_modified">{{displayDate}}</span>
-            </div>     
+            </div>
             <div class="col-md-2 visible-lg visible-md valign support">
                 {{this.model.description}}
             </div>

--- a/src/app/files/file-list.ts
+++ b/src/app/files/file-list.ts
@@ -68,7 +68,8 @@ import { FileNavService } from './file-nav.service';
                     (dragstart)="drag(child, $event)"
                     (drop)="drop($event, child)"
                     (dragenter)="onDragItemEnter(child, $event)"
-                    (dragleave)="onDragItemLeave(child, $event)">
+                    (dragleave)="onDragItemLeave(child, $event)"
+                    (keyup.space)="select(child)">
                     <file [model]="child" (modelChanged)="doSort()"></file>
                 </li>
             </virtual-list>
@@ -404,6 +405,11 @@ export class FileListComponent implements OnInit, OnDestroy {
         else if (e.dataTransfer.effectAllowed == "all") {
             e.dataTransfer.dropEffect = "copy";
         }
+    }
+
+    private select(f) {
+        this.clearSelection();
+        this._selected.push(f);
     }
 
     private drag(f: ApiFile, e: DragEvent) {

--- a/src/app/files/navigation.component.ts
+++ b/src/app/files/navigation.component.ts
@@ -18,7 +18,7 @@ export class Drop {
         <div>
             <button class="no-border pull-left color-active" title="Go Up" (click)="onClickUp()"><i class="fa fa-level-up"></i></button>
             <div class="fill">
-                <ul *ngIf="_crumbs.length > 0" [hidden]="_typing" class="nav border-color" (click)="onClickAddress($event)">
+                <ul tabindex="0" *ngIf="_crumbs.length > 0" [hidden]="_typing" class="nav border-color" (keyup.space)="onClickAddress($event)" (keyup.enter)="onClickAddress($event)" (click)="onClickAddress($event)">
                     <li *ngFor="let item of _crumbs; let i = index;" 
                         (dragover)="dragOver(i, $event)" 
                         (drop)="onDrop(i, $event)"
@@ -39,6 +39,14 @@ export class Drop {
             cursor: pointer;
             padding: 0 1px;
             direction: ltr;
+        }
+
+        ul:focus {
+            outline-style: dashed;
+            outline-color: #000;
+            outline-width: 2px;
+            outline-offset: -2px;
+            text-decoration: underline;
         }
 
         .crumb:empty:before {

--- a/src/app/settings/server-list-item.ts
+++ b/src/app/settings/server-list-item.ts
@@ -14,7 +14,7 @@ import { NotificationService } from '../notification/notification.service';
             <div *ngIf="!_editing">
                 <div class="col-xs-10 col-sm-4 v-align">
                     <a title="Connect" href="#" class="color-normal hover-color-active" [class.active]="_active === model" (click)="onConnect($event)">{{connName()}}</a>
-                </div>     
+                </div>
                 <div class="hidden-xs col-sm-6 v-align">
                     {{model.url}}
                 </div>

--- a/src/app/webserver/app-pools/app-pool-general.component.ts
+++ b/src/app/webserver/app-pools/app-pool-general.component.ts
@@ -12,7 +12,7 @@ import {ApplicationPool} from './app-pool';
             <tab [name]="'Settings'">
                 <fieldset>
                     <label>Name</label>
-                    <input class="form-control name" type="text" [(ngModel)]="pool.name" (modelChanged)="onModelChanged()" required throttle />
+                    <input autofocus class="form-control name" type="text" [(ngModel)]="pool.name" (modelChanged)="onModelChanged()" required throttle />
                 </fieldset>
                 <fieldset>
                     <label>Auto Start</label>

--- a/src/app/webserver/app-pools/app-pool-list.component.ts
+++ b/src/app/webserver/app-pools/app-pool-list.component.ts
@@ -14,7 +14,7 @@ import {AppPoolList} from './app-pool-list';
         <div>
             <button [class.background-active]="newAppPool.opened" (click)="newAppPool.toggle()">Create Application Pool <i class="fa fa-caret-down"></i></button>
             <selector #newAppPool class="container-fluid">
-                <new-app-pool (created)="newAppPool.close()" (cancel)="newAppPool.close()"></new-app-pool>
+                <new-app-pool *ngIf="newAppPool.opened" (created)="newAppPool.close()" (cancel)="newAppPool.close()"></new-app-pool>
             </selector>
         </div>
         <br/>

--- a/src/app/webserver/app-pools/app-pools.module.ts
+++ b/src/app/webserver/app-pools/app-pools.module.ts
@@ -13,6 +13,7 @@ import { Module as Loading } from '../../notification/loading.component';
 import { Module as Enum } from '../../common/enum.component';
 import { Module as StringList } from '../../common/string-list.component';
 import { Module as Tabs } from '../../common/tabs.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { Module } from './module';
 import { Routing } from './app-pool.routes';
@@ -41,7 +42,8 @@ import { DailyScheduleComponent, RecyclingComponent } from './recycling.componen
         Loading,
         Enum,
         StringList,
-        Tabs
+        Tabs,
+        AutoFocus,
     ],
     declarations: [
         AppPoolComponent,

--- a/src/app/webserver/app-pools/module.ts
+++ b/src/app/webserver/app-pools/module.ts
@@ -10,6 +10,7 @@ import { Module as Loading } from '../../notification/loading.component';
 import { Module as Sort } from '../../common/sort.pipe';
 import { Module as Selector } from '../../common/selector';
 import { Module as Enum } from '../../common/enum.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { AppPoolList, AppPoolItem } from './app-pool-list';
 import { AppPoolListComponent } from './app-pool-list.component';
@@ -27,7 +28,8 @@ import { IdentityComponent } from './identity.component';
         Loading,
         Sort,
         Selector,
-        Enum
+        Enum,
+        AutoFocus,
     ],
     exports: [
         AppPoolList,

--- a/src/app/webserver/app-pools/new-app-pool.component.ts
+++ b/src/app/webserver/app-pools/new-app-pool.component.ts
@@ -10,7 +10,7 @@ import {AppPoolsService} from './app-pools.service';
     template: `
         <fieldset>
             <label>Name</label>
-            <input type="text" class="form-control name" [(ngModel)]="model.name" required />
+            <input autofocus type="text" class="form-control name" [(ngModel)]="model.name" required />
         </fieldset>
         <section>
             <div class="collapse-heading collapsed" data-toggle="collapse" data-target="#settings">

--- a/src/app/webserver/app-pools/recycling.component.ts
+++ b/src/app/webserver/app-pools/recycling.component.ts
@@ -98,7 +98,7 @@ export class DailyScheduleComponent {
                     <label>Memory Limit <span class="units">(KB)</span></label>
                     <input class="form-control" type="number" [(ngModel)]="model.periodic_restart.private_memory" throttle (modelChanged)="onModelChanged()" />
                 </fieldset>
-            </div>    
+            </div>
             <div>
                 <fieldset class='inline-block'>
                     <label>Virtual Memory</label>
@@ -110,7 +110,7 @@ export class DailyScheduleComponent {
                     <label>Memory Limit <span class="units">(KB)</span></label>
                     <input class="form-control" type="number" [(ngModel)]="model.periodic_restart.virtual_memory" throttle (modelChanged)="onModelChanged()" />
                 </fieldset>
-            </div>    
+            </div>
             <div>
                 <fieldset class='inline-block'>
                     <label>Request Limit</label>

--- a/src/app/webserver/authentication/anon-auth.component.ts
+++ b/src/app/webserver/authentication/anon-auth.component.ts
@@ -24,8 +24,8 @@ import { AuthenticationService } from './authentication.service';
                 <fieldset>
                     <label>Password</label>
                     <input class="form-control path" type="text" [disabled]="_locked" [(ngModel)]="_model.password" throttle (modelChanged)="onModelChanged()" />
-                </fieldset>  
-            </div>  
+                </fieldset>
+            </div>
         </div>
     `
 })

--- a/src/app/webserver/authorization/rule-edit.component.ts
+++ b/src/app/webserver/authorization/rule-edit.component.ts
@@ -6,7 +6,7 @@ import { AuthorizationService } from './authorization.service';
 @Component({
     selector: 'edit-rule',
     template: `
-        <div>   
+        <div>
             <fieldset>
                 <label class="inline-block">Access Type</label>
                 <enum class="block" [disabled]="locked" [(model)]="rule.access_type">

--- a/src/app/webserver/authorization/rule-edit.component.ts
+++ b/src/app/webserver/authorization/rule-edit.component.ts
@@ -23,7 +23,7 @@ import { AuthorizationService } from './authorization.service';
                     <field name="Roles or Groups" value="roles"></field>
                 </enum>
             </fieldset>
-            <fieldset class="no-label" *ngIf="_target == 'roles' || _target == 'users'">   
+            <fieldset class="no-label" *ngIf="_target == 'roles' || _target == 'users'">
                 <div *ngIf="_target == 'roles'">
                     <input placeholder="ex: Administrators, Power Users" class="form-control name" type="text" [disabled]="locked" [(ngModel)]="_roles" />
                 </div>

--- a/src/app/webserver/central-certificates/central-certificate.component.ts
+++ b/src/app/webserver/central-certificates/central-certificate.component.ts
@@ -23,10 +23,8 @@ import { CentralCertificateConfiguration } from './central-certificates';
         <div *ngIf="_configuration">
             <fieldset class="path">
                 <label>Physical Path</label>
-                <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="right select" (click)="fileSelector.toggle()" [attr.disabled]="isPending || null" ></button>
-                <div class="fill">
-                    <input type="text" class="form-control" [(ngModel)]="_configuration.path" (modelChanged)="onModelChanged()" throttle required [attr.disabled]="isPending || null" />
-                </div>
+                <input type="text" class="form-control left-with-button" [(ngModel)]="_configuration.path" (modelChanged)="onModelChanged()" throttle required [attr.disabled]="isPending || null" />
+                <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()" [attr.disabled]="isPending || null" ></button>
                 <server-file-selector #fileSelector (selected)="onSelectPath($event)" [defaultPath]="_configuration.path" [types]="['directory']"></server-file-selector>
             </fieldset>
             <label class="block">Connection Credentials</label>

--- a/src/app/webserver/compression/compression.component.ts
+++ b/src/app/webserver/compression/compression.component.ts
@@ -37,10 +37,8 @@ import { NotificationService } from '../../notification/notification.service';
             <div *ngIf="!model.scope">
                 <fieldset class="path">
                     <label>Directory</label>
-                    <button title="Select Directory" [class.background-active]="fileSelector.isOpen()" class="right select" (click)="fileSelector.toggle()"></button>
-                    <div class="fill">
-                        <input type="text" class="form-control" [(ngModel)]="model.directory" (modelChanged)="onModelChanged()" throttle required />
-                    </div>
+                    <input type="text" class="form-control left-with-button" [(ngModel)]="model.directory" (modelChanged)="onModelChanged()" throttle required />
+                    <button title="Select Directory" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
                     <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="model.directory" (selected)="onSelectPath($event)"></server-file-selector>
                 </fieldset>
                 <fieldset class="inline-block">

--- a/src/app/webserver/default-documents/file-list.component.ts
+++ b/src/app/webserver/default-documents/file-list.component.ts
@@ -10,6 +10,10 @@ import { DefaultDocumentsService } from './default-documents.service';
     selector: 'file',
     template: `        
         <div *ngIf="model" class="grid-item row" [class.background-editing]="_editing">
+            <fieldset class="col-xs-8">
+                <input *ngIf="_editing" class="form-control" type="text" [(ngModel)]="model.name" required />
+                <span *ngIf="!_editing" class="form-control">{{model.name}}</span>
+            </fieldset>
             <div class="actions">
                 <button class="no-border no-editing" [class.inactive]="readonly" title="Edit" (click)="onEdit()">
                     <i class="fa fa-pencil color-active"></i>
@@ -24,10 +28,6 @@ import { DefaultDocumentsService } from './default-documents.service';
                     <i class="fa fa-trash-o red"></i>
                 </button>
             </div>
-            <fieldset class="col-xs-8">
-                <input *ngIf="_editing" class="form-control" type="text" [(ngModel)]="model.name" required />
-                <span *ngIf="!_editing" class="form-control">{{model.name}}</span>
-            </fieldset>
         </div>
     `,
     styles: [`

--- a/src/app/webserver/files/webfile-list-item.ts
+++ b/src/app/webserver/files/webfile-list-item.ts
@@ -31,7 +31,7 @@ import { WebFileType, WebFile } from './webfile';
             </div>
             <div class="col-sm-3 col-md-2 hidden-xs valign support">
                 <span *ngIf="model.file_info && model.file_info.last_modified">{{displayDate}}</span>
-            </div>     
+            </div>
             <div class="col-md-2 visible-lg visible-md valign support">
                 {{this.model.description}}
             </div>

--- a/src/app/webserver/http-response-headers/custom-headers.component.ts
+++ b/src/app/webserver/http-response-headers/custom-headers.component.ts
@@ -15,6 +15,21 @@ import {HttpResponseHeaders, CustomHeader} from './http-response-headers';
         <ul class="grid-list container-fluid">
             <li *ngFor="let header of headers; let i = index;">
                 <div class="row grid-item" [class.background-editing]="_editing == i">
+                    <fieldset class="col-xs-8 col-sm-4 col-lg-5 overflow-visible">
+                        <label class="visible-xs">Name</label>
+                        <label *ngIf="_editing == i" class="hidden-xs">Name</label>
+                        <span *ngIf="_editing != i">{{header.name}}</span>
+                        <input autofocus *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.name" throttle required />
+                        <div *ngIf="_editing !== i">
+                            <br class="visible-xs" />
+                        </div>
+                    </fieldset>
+                    <fieldset class="col-xs-12 col-sm-5 col-lg-5">
+                        <label class="visible-xs">Value</label>
+                        <label *ngIf="_editing == i" class="hidden-xs">Value</label>
+                        <span *ngIf="_editing != i">{{header.value}}</span>
+                        <input *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.value" throttle required />
+                    </fieldset>
                     <div class="actions">
                         <button class="no-border" title="Ok" [disabled]="locked || !isValid(header) || null" *ngIf="_editing == i" (click)="onFinishEditing(i)">
                             <i class="fa fa-check color-active"></i>
@@ -29,21 +44,6 @@ import {HttpResponseHeaders, CustomHeader} from './http-response-headers';
                             <i class="fa fa-trash-o red"></i>
                         </button>
                     </div>
-                    <fieldset class="col-xs-8 col-sm-4 col-lg-5">
-                        <label class="visible-xs">Name</label>
-                        <label *ngIf="_editing == i" class="hidden-xs">Name</label>
-                        <span *ngIf="_editing != i">{{header.name}}</span>
-                        <input *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.name" throttle required />
-                        <div *ngIf="_editing !== i">
-                            <br class="visible-xs" />
-                        </div>
-                    </fieldset>
-                    <fieldset class="col-xs-12 col-sm-5 col-lg-5">
-                        <label class="visible-xs">Value</label>
-                        <label *ngIf="_editing == i" class="hidden-xs">Value</label>
-                        <span *ngIf="_editing != i">{{header.value}}</span>
-                        <input *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.value" throttle required />
-                    </fieldset>
                 </div>
             </li>
         </ul>

--- a/src/app/webserver/http-response-headers/custom-headers.component.ts
+++ b/src/app/webserver/http-response-headers/custom-headers.component.ts
@@ -15,20 +15,22 @@ import {HttpResponseHeaders, CustomHeader} from './http-response-headers';
         <ul class="grid-list container-fluid">
             <li *ngFor="let header of headers; let i = index;">
                 <div class="row grid-item" [class.background-editing]="_editing == i">
-                    <fieldset class="col-xs-8 col-sm-4 col-lg-5 overflow-visible">
-                        <label class="visible-xs">Name</label>
-                        <label *ngIf="_editing == i" class="hidden-xs">Name</label>
-                        <span *ngIf="_editing != i">{{header.name}}</span>
-                        <input autofocus *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.name" throttle required />
-                        <div *ngIf="_editing !== i">
-                            <br class="visible-xs" />
-                        </div>
-                    </fieldset>
-                    <fieldset class="col-xs-12 col-sm-5 col-lg-5">
-                        <label class="visible-xs">Value</label>
-                        <label *ngIf="_editing == i" class="hidden-xs">Value</label>
-                        <span *ngIf="_editing != i">{{header.value}}</span>
-                        <input *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.value" throttle required />
+                    <fieldset class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
+                        <fieldset class="col-xs-8 col-sm-4 col-lg-5">
+                            <label class="visible-xs">Name</label>
+                            <label *ngIf="_editing == i" class="hidden-xs">Name</label>
+                            <span *ngIf="_editing != i">{{header.name}}</span>
+                            <input autofocus *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.name" throttle required />
+                            <div *ngIf="_editing !== i">
+                                <br class="visible-xs" />
+                            </div>
+                        </fieldset>
+                        <fieldset class="col-xs-12 col-sm-5 col-lg-5">
+                            <label class="visible-xs">Value</label>
+                            <label *ngIf="_editing == i" class="hidden-xs">Value</label>
+                            <span *ngIf="_editing != i">{{header.value}}</span>
+                            <input *ngIf="_editing == i" class="form-control" type="text" [disabled]="locked" [(ngModel)]="header.value" throttle required />
+                        </fieldset>
                     </fieldset>
                     <div class="actions">
                         <button class="no-border" title="Ok" [disabled]="locked || !isValid(header) || null" *ngIf="_editing == i" (click)="onFinishEditing(i)">

--- a/src/app/webserver/http-response-headers/http-response-headers.module.ts
+++ b/src/app/webserver/http-response-headers/http-response-headers.module.ts
@@ -8,6 +8,7 @@ import { Module as Loading } from '../../notification/loading.component';
 import { Module as OverrideMode } from '../../common/override-mode.component';
 import { Module as ErrorComponent } from '../../error/error.component';
 import { Module as Tabs } from '../../common/tabs.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { HttpResponseHeadersService } from './http-response-headers.service';
 
@@ -24,7 +25,8 @@ import { RedirectHeadersComponent } from './redirect-headers.component';
         Loading,
         OverrideMode,
         ErrorComponent,
-        Tabs
+        Tabs,
+        AutoFocus,
     ],
     declarations: [
         CustomHeadersComponent,

--- a/src/app/webserver/http-response-headers/redirect-headers.component.ts
+++ b/src/app/webserver/http-response-headers/redirect-headers.component.ts
@@ -15,6 +15,21 @@ import {HttpResponseHeaders, RedirectHeader} from './http-response-headers';
         <ul class="grid-list container-fluid">
             <li *ngFor="let header of headers; let i = index;">
                 <div class="row grid-item" [class.background-editing]="_editing == i">
+                    <fieldset class="col-xs-12 col-sm-4 col-lg-5">
+                        <label class="visible-xs">Name</label>
+                        <label *ngIf="_editing == i" class="hidden-xs">Name</label>
+                        <span *ngIf="_editing != i">{{header.name}}</span>
+                        <input autofocus *ngIf="_editing == i" [disabled]="locked" class="form-control" type="text" [(ngModel)]="header.name" throttle required />
+                        <div *ngIf="_editing !== i">
+                            <br class="visible-xs" />
+                        </div>
+                    </fieldset>
+                    <fieldset class="col-xs-12 col-sm-6 col-lg-5">
+                        <label class="visible-xs">Value</label>
+                        <label *ngIf="_editing == i" class="hidden-xs">Value</label>
+                        <span *ngIf="_editing != i">{{header.value}}</span>
+                        <input *ngIf="_editing == i" [disabled]="locked" class="form-control" type="text" [(ngModel)]="header.value" throttle required />
+                    </fieldset>
                     <div class="actions">
                         <button class="no-border" [disabled]="locked || !isValid(header) || null" title="Ok" *ngIf="_editing == i" (click)="onFinishEditing(i)">
                             <i class="fa fa-check color-active"></i>
@@ -29,21 +44,6 @@ import {HttpResponseHeaders, RedirectHeader} from './http-response-headers';
                             <i class="fa fa-trash-o red"></i>
                         </button>
                     </div>
-                    <fieldset class="col-xs-12 col-sm-4 col-lg-5">
-                        <label class="visible-xs">Name</label>
-                        <label *ngIf="_editing == i" class="hidden-xs">Name</label>
-                        <span *ngIf="_editing != i">{{header.name}}</span>
-                        <input *ngIf="_editing == i" [disabled]="locked" class="form-control" type="text" [(ngModel)]="header.name" throttle required />
-                        <div *ngIf="_editing !== i">
-                            <br class="visible-xs" />
-                        </div>
-                    </fieldset>
-                    <fieldset class="col-xs-12 col-sm-6 col-lg-5">
-                        <label class="visible-xs">Value</label>
-                        <label *ngIf="_editing == i" class="hidden-xs">Value</label>
-                        <span *ngIf="_editing != i">{{header.value}}</span>
-                        <input *ngIf="_editing == i" [disabled]="locked" class="form-control" type="text" [(ngModel)]="header.value" throttle required />
-                    </fieldset>
                 </div>
             </li>
         </ul>

--- a/src/app/webserver/ip-restrictions/ip-restrictions.component.ts
+++ b/src/app/webserver/ip-restrictions/ip-restrictions.component.ts
@@ -37,7 +37,7 @@ import { NotificationService } from '../../notification/notification.service';
                             <restriction-rules [ipRestrictions]="ipRestrictions" (modelChange)="onModelChanged()"></restriction-rules>
                     </tab>
                 </tabs>
-            </div>            
+            </div>
         </div>
     `,
     styles: [`

--- a/src/app/webserver/logging/log-file.component.ts
+++ b/src/app/webserver/logging/log-file.component.ts
@@ -16,7 +16,7 @@ import { FilesService } from '../../files/files.service';
             </div>
             <div class="col-sm-3 col-md-2 hidden-xs valign support">
                 <span *ngIf="model.last_modified">{{displayDate}}</span>
-            </div>     
+            </div>
             <div class="col-md-2 visible-lg visible-md valign support">
                 {{this.model.description}}
             </div>

--- a/src/app/webserver/logging/logfields.component.ts
+++ b/src/app/webserver/logging/logfields.component.ts
@@ -67,26 +67,12 @@ export class LogFieldsComponent {
     </div>
     <ul class="grid-list">
         <li *ngFor="let field of fields; let i = index;" class="row border-color grid-item" [class.background-editing]="i === _editing">
-            <div class="actions">
-                <button class="no-border no-editing" title="Edit" [class.inactive]="_editing != -1" (click)="edit(i)" >
-                    <i class="fa fa-pencil color-active"></i>
-                </button>
-                <button [disabled]="!isValidCustomField(field)" class="no-border editing" title="Ok" (click)="save(i)">
-                    <i class="fa fa-check color-active"></i>
-                </button>
-                <button class="no-border editing" title="Cancel" (click)="discardChanges(i)">
-                    <i class="fa fa-times red"></i>
-                </button>
-                <button class="no-border" title="Delete" *ngIf="!field.isNew" [class.inactive]="_editing !== -1 && _editing !== i" (click)="delete(i)">
-                    <i class="fa fa-trash-o red"></i>
-                </button>
-            </div>
             <div class="col-xs-8 col-sm-3 col-lg-2">
                 <fieldset>
                     <label class="visible-xs">Read From</label>
                     <label *ngIf="i === _editing" class="hidden-xs">Read From</label>
                     <span *ngIf="i !== _editing">{{sourceTypeName(field.source_type)}}</span>
-                    <select *ngIf="i === _editing" [(ngModel)]="field.source_type" class="form-control">
+                    <select autofocus *ngIf="i === _editing" [(ngModel)]="field.source_type" class="form-control">
                         <option value="request_header">Request Header</option>
                         <option value="response_header">Response Header</option>
                         <option value="server_variable">Server Variable</option>
@@ -117,6 +103,20 @@ export class LogFieldsComponent {
                 <div *ngIf="i !== _editing">
                     <br class="visible-xs" />
                 </div>
+            </div>
+            <div class="actions">
+                <button class="no-border no-editing" title="Edit" [class.inactive]="_editing != -1" (click)="edit(i)" >
+                    <i class="fa fa-pencil color-active"></i>
+                </button>
+                <button [disabled]="!isValidCustomField(field)" class="no-border editing" title="Ok" (click)="save(i)">
+                    <i class="fa fa-check color-active"></i>
+                </button>
+                <button class="no-border editing" title="Cancel" (click)="discardChanges(i)">
+                    <i class="fa fa-times red"></i>
+                </button>
+                <button class="no-border" title="Delete" *ngIf="!field.isNew" [class.inactive]="_editing !== -1 && _editing !== i" (click)="delete(i)">
+                    <i class="fa fa-trash-o red"></i>
+                </button>
             </div>
         </li>
     </ul>

--- a/src/app/webserver/logging/logging.component.ts
+++ b/src/app/webserver/logging/logging.component.ts
@@ -35,10 +35,8 @@ import { NotificationService } from '../../notification/notification.service';
                 <tab *ngIf="'true'" [name]="'Settings'">
                     <fieldset class="path">
                         <label>Directory</label>
-                        <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="right select" (click)="fileSelector.toggle()"></button>
-                        <div class="fill">
-                            <input [disabled]="!logging.log_per_site && logging.website" type="text" class="form-control" [(ngModel)]="logging.directory" throttle (modelChanged)="onModelChanged()" throttle required />
-                        </div>
+                        <input [disabled]="!logging.log_per_site && logging.website" type="text" class="form-control left-with-button" [(ngModel)]="logging.directory" throttle (modelChanged)="onModelChanged()" throttle required />
+                        <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
                         <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="logging.directory" (selected)="onSelectPath($event)"></server-file-selector>
                     </fieldset>
                     <fieldset *ngIf="!logging.website">

--- a/src/app/webserver/logging/logging.module.ts
+++ b/src/app/webserver/logging/logging.module.ts
@@ -16,6 +16,7 @@ import { Module as Selectable } from '../../common/selectable';
 import { Module as Toolbar } from '../../files/toolbar.component';
 import { Module as Warning } from '../../notification/warning.component';
 import { Module as Tabs } from '../../common/tabs.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { FilesModule } from '../../files/files.module';
 
@@ -45,7 +46,8 @@ import { LogFilesComponent } from './log-files.component';
         Toolbar,
         Warning,
         FilesModule,
-        Tabs
+        Tabs,
+        AutoFocus,
     ],
     declarations: [
         FormatComponent,

--- a/src/app/webserver/mime-maps/mime-maps-list.component.ts
+++ b/src/app/webserver/mime-maps/mime-maps-list.component.ts
@@ -171,7 +171,7 @@ export class MimeMapListItem implements OnInit, OnChanges {
                     <mime-map [model]="m" (enter)="onEnter()" (leave)="onLeave()"></mime-map>
                 </li>
             </ul>
-        </div>  
+        </div>
     `
 })
 export class MimeMapsListComponent implements OnInit, OnDestroy {

--- a/src/app/webserver/mime-maps/mime-maps-list.component.ts
+++ b/src/app/webserver/mime-maps/mime-maps-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnChanges, OnDestroy, SimpleChange, Input, Output, EventEmitter, ViewChildren, QueryList, ElementRef } from '@angular/core';
+import { Component, OnInit, OnChanges, OnDestroy, SimpleChange, Input, Output, EventEmitter, ViewChildren, QueryList, ElementRef, ViewChild } from '@angular/core';
 
 import { Subscription } from 'rxjs/Subscription';
 
@@ -11,6 +11,23 @@ import { StaticContentService } from '../static-content/static-content.service';
     selector: 'mime-map',
     template: `        
         <div *ngIf="model" class="grid-item row" [class.background-editing]="_editing">
+
+            <fieldset class="col-xs-8 col-sm-3 col-md-4">
+                <label class="visible-xs">File Extension</label>
+                <label class="hidden-xs" *ngIf="_editing">File Extension</label>
+                <input autofocus *ngIf="_editing" class="form-control" type="text" [(ngModel)]="model.file_extension" throttle required />
+                <span *ngIf="!_editing">{{model.file_extension}}</span>
+                <div *ngIf="!_editing">
+                    <br class="visible-xs" />
+                </div>
+            </fieldset>
+
+            <fieldset class="col-xs-12 col-sm-5 col-md-4">
+                <label class="visible-xs">Mime Type</label>
+                <label class="hidden-xs" *ngIf="_editing">Mime Type</label>
+                <input *ngIf="_editing" class="form-control" type="text" [(ngModel)]="model.mime_type" throttle required />
+                <span *ngIf="!_editing">{{model.mime_type}}</span>
+            </fieldset>
 
             <div class="actions">
                 <button *ngIf="!_editing" class="no-border" [class.inactive]="!_editable" title="Edit" (click)="onEdit()">
@@ -26,23 +43,6 @@ import { StaticContentService } from '../static-content/static-content.service';
                     <i class="fa fa-trash-o red"></i>
                 </button>
             </div>
-
-            <fieldset class="col-xs-8 col-sm-3 col-md-4">
-                <label class="visible-xs">File Extension</label>
-                <label class="hidden-xs" *ngIf="_editing">File Extension</label>
-                <input *ngIf="_editing" class="form-control" type="text" [(ngModel)]="model.file_extension" throttle required />
-                <span *ngIf="!_editing">{{model.file_extension}}</span>
-                <div *ngIf="!_editing">
-                    <br class="visible-xs" />
-                </div>
-            </fieldset>
-
-            <fieldset class="col-xs-12 col-sm-5 col-md-4">
-                <label class="visible-xs">Mime Type</label>
-                <label class="hidden-xs" *ngIf="_editing">Mime Type</label>
-                <input *ngIf="_editing" class="form-control" type="text" [(ngModel)]="model.mime_type" throttle required />
-                <span *ngIf="!_editing">{{model.mime_type}}</span>
-            </fieldset>
 
         </div>
     `,
@@ -84,6 +84,8 @@ export class MimeMapListItem implements OnInit, OnChanges {
     public setEditable(val: boolean) {
         this._editable = val;
     }
+
+
 
     private onEdit() {
         this.enter.emit(null);

--- a/src/app/webserver/mime-maps/mime-maps.module.ts
+++ b/src/app/webserver/mime-maps/mime-maps.module.ts
@@ -7,6 +7,7 @@ import { Module as BModel } from '../../common/bmodel';
 import { Module as Loading } from '../../notification/loading.component';
 import { Module as OverrideMode } from '../../common/override-mode.component';
 import { Module as ErrorComponent } from '../../error/error.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { StaticContentService } from '../static-content/static-content.service';
 
@@ -21,7 +22,8 @@ import { MimeMapsComponent } from './mime-maps.component';
         BModel,
         Loading,
         OverrideMode,
-        ErrorComponent
+        ErrorComponent,
+        AutoFocus,
     ],
     declarations: [
         MimeMapListItem,

--- a/src/app/webserver/modules/module.component.ts
+++ b/src/app/webserver/modules/module.component.ts
@@ -29,24 +29,18 @@ import {LocalModule, GlobalModule} from './modules';
         .visible-xs-inline-block {
             margin-left: 15px;
         }
+
+        .switch-wrapper {
+            // outline-style: dashed;
+            // outline-color: #000;
+            // outline-width: 2px;
+            // outline-offset: -2px;
+            // text-decoration: underline;
+            outline: none;
+        }
     `],
     template: `
         <div *ngIf="module" class="row grid-item" [class.background-editing]="_isEditing">
-
-            <div class="actions" [ngClass]="actionClasses()">
-                <button class="no-border" title="Ok" *ngIf="_isEditing" (click)="onFinishEditing()">
-                    <i class="fa fa-check blue"></i>
-                </button>
-                <button class="no-border" title="Cancel" *ngIf="_isEditing" (click)="onDiscardChanges()">
-                    <i class="fa fa-times red"></i>
-                </button>
-                <button class="no-border" title="Edit" [disabled]="!_editable" *ngIf="!_isEditing && allow('edit')" (click)="onEdit()">
-                    <i class="fa fa-pencil blue"></i>
-                </button>
-                <button class="no-border" title="Delete" [disabled]="!_editable" *ngIf="allow('delete')" (click)="onDelete()">
-                    <i class="fa fa-trash-o red"></i>
-                </button>
-            </div>
 
             <fieldset class="col-xs-8 col-sm-3">
                 <label class="hidden-xs editing">Name</label>
@@ -67,13 +61,31 @@ import {LocalModule, GlobalModule} from './modules';
             </fieldset>
             <fieldset class="col-xs-8 col-sm-3 col-md-3 col-lg-2">
                 <label class="editing"><span class="visible-xs-inline-block"></span>Status</label>
-                <div [hidden]="!_isEditing">
+                <div *ngIf="_isEditing">
                     <span class="visible-xs-inline-block"></span>
-                    <switch [(model)]="enabled">{{enabled ? 'Enabled' : 'Disabled'}}</switch>
+                    <span class="switch-wrapper" autofocus tabindex="0">
+                        <switch #switchButton [(model)]="enabled"></switch>
+                    </span>
+                    {{enabled ? 'Enabled' : 'Disabled'}}
                 </div>
                 <span *ngIf="!_isEditing" class="visible-xs-inline-block"></span>
                 <span *ngIf="!_isEditing" [class.stopped]="!enabled" [class.green]="enabled">{{enabled ? 'Enabled' : 'Disabled'}}</span>
             </fieldset>
+
+            <div class="actions" [ngClass]="actionClasses()">
+                <button class="no-border" title="Ok" *ngIf="_isEditing" (click)="onFinishEditing()">
+                    <i class="fa fa-check blue"></i>
+                </button>
+                <button class="no-border" title="Cancel" *ngIf="_isEditing" (click)="onDiscardChanges()">
+                    <i class="fa fa-times red"></i>
+                </button>
+                <button class="no-border" title="Edit" [disabled]="!_editable" *ngIf="!_isEditing && allow('edit')" (click)="onEdit()">
+                    <i class="fa fa-pencil blue"></i>
+                </button>
+                <button class="no-border" title="Delete" [disabled]="!_editable" *ngIf="allow('delete')" (click)="onDelete()">
+                    <i class="fa fa-trash-o red"></i>
+                </button>
+            </div>
 
         </div>
     `

--- a/src/app/webserver/modules/module.component.ts
+++ b/src/app/webserver/modules/module.component.ts
@@ -31,11 +31,6 @@ import {LocalModule, GlobalModule} from './modules';
         }
 
         .switch-wrapper {
-            // outline-style: dashed;
-            // outline-color: #000;
-            // outline-width: 2px;
-            // outline-offset: -2px;
-            // text-decoration: underline;
             outline: none;
         }
     `],

--- a/src/app/webserver/modules/modules.component.ts
+++ b/src/app/webserver/modules/modules.component.ts
@@ -10,7 +10,7 @@ import {Modules, LocalModule, GlobalModule} from './modules';
     selector: 'modules',
     template: `
         <loading *ngIf="!(modules || _error)"></loading>
-        <error [error]="_error"></error>        
+        <error [error]="_error"></error>
         <div *ngIf="modules">
             <override-mode class="pull-right" [metadata]="modules.metadata" (revert)="onRevert()" (modelChanged)="onModelChanged()"></override-mode>
             <module-list [enabledNativeModules] = "enabledNativeModules"

--- a/src/app/webserver/modules/modules.module.ts
+++ b/src/app/webserver/modules/modules.module.ts
@@ -8,6 +8,7 @@ import {Module as Loading} from '../../notification/loading.component';
 import {Module as OverrideMode} from '../../common/override-mode.component';
 import {Module as Enum} from '../../common/enum.component';
 import {Module as ErrorComponent} from '../../error/error.component';
+import {Module as AutoFocus} from '../../common/focus';
 
 import {ModuleService} from './modules.service';
 
@@ -25,7 +26,8 @@ import {NewModuleComponent} from './new-module.component';
         Loading,
         OverrideMode,
         Enum,
-        ErrorComponent
+        ErrorComponent,
+        AutoFocus,
     ],
     declarations: [
         ModuleListComponent,

--- a/src/app/webserver/modules/new-module.component.ts
+++ b/src/app/webserver/modules/new-module.component.ts
@@ -42,7 +42,7 @@ import {LocalModule, GlobalModule, ModuleType} from './modules';
                 <button class="no-border" (click)="onCancel()">
                     <i class="fa fa-times red" title="Cancel"></i>
                 </button>
-            </div>            
+            </div>
         </div>
     `
 })

--- a/src/app/webserver/modules/new-module.component.ts
+++ b/src/app/webserver/modules/new-module.component.ts
@@ -6,7 +6,7 @@ import {LocalModule, GlobalModule, ModuleType} from './modules';
     selector: 'new-module',
     template: `
         <div class="grid-item background-editing row">
-            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible">
+            <div class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
                 <fieldset class="col-xs-8" *ngIf="isServerSetting">
                     <enum [(model)]="moduleType">
                         <field name="Managed" value="managed"></field>

--- a/src/app/webserver/modules/new-module.component.ts
+++ b/src/app/webserver/modules/new-module.component.ts
@@ -6,6 +6,35 @@ import {LocalModule, GlobalModule, ModuleType} from './modules';
     selector: 'new-module',
     template: `
         <div class="grid-item background-editing row">
+            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible">
+                <fieldset class="col-xs-8" *ngIf="isServerSetting">
+                    <enum [(model)]="moduleType">
+                        <field name="Managed" value="managed"></field>
+                        <field name="Native" value="native"></field>
+                    </enum>
+                </fieldset>
+                <div class="col-xs-12" *ngIf="isServerSetting"></div>
+                <div class="col-xs-12" *ngIf="moduleType != 'native'">
+                    <fieldset>
+                        <label>Name</label>
+                        <input autofocus class="form-control" type="text" [(ngModel)]="newManagedModule.name" throttle required />
+                    </fieldset>
+                    <fieldset>
+                        <label>Type</label>
+                        <input class="form-control" type="text" [(ngModel)]="newManagedModule.type" throttle required />
+                    </fieldset>
+                </div>
+                <div class="col-xs-12" *ngIf="moduleType == 'native'">
+                    <fieldset *ngIf="moduleType == 'native'">
+                        <label>Name</label>
+                        <input autofocus class="form-control" type="text" [(ngModel)]="newNativeModule.name" throttle required />
+                    </fieldset>
+                    <fieldset *ngIf="moduleType == 'native'">
+                        <label>Image</label>
+                        <input class="form-control" type="text" [(ngModel)]="newNativeModule.image" throttle required />
+                    </fieldset>
+                </div>
+            </div>
             <div class="actions">
                 <button class="no-border" [disabled]="!isValid()" (click)="onSave()">
                     <i class="fa fa-check color-active" title="Save"></i>
@@ -13,30 +42,7 @@ import {LocalModule, GlobalModule, ModuleType} from './modules';
                 <button class="no-border" (click)="onCancel()">
                     <i class="fa fa-times red" title="Cancel"></i>
                 </button>
-            </div>
-            <fieldset class="col-xs-8" *ngIf="isServerSetting">
-                <enum [(model)]="moduleType">
-                    <field name="Managed" value="managed"></field>
-                    <field name="Native" value="native"></field>
-                </enum>
-            </fieldset>
-            <div class="col-xs-12" *ngIf="isServerSetting"></div>
-            <fieldset class="col-sm-4 col-md-5" *ngIf="moduleType != 'native'">
-                <label>Name</label>
-                <input class="form-control" type="text" [(ngModel)]="newManagedModule.name" throttle required />
-            </fieldset>
-            <fieldset class="col-sm-5" *ngIf="moduleType != 'native'">
-                <label>Type</label>
-                <input class="form-control" type="text" [(ngModel)]="newManagedModule.type" throttle required />
-            </fieldset>
-            <fieldset class="col-sm-4 col-md-5" *ngIf="moduleType == 'native'">
-                <label>Name</label>
-                <input class="form-control" type="text" [(ngModel)]="newNativeModule.name" throttle required />
-            </fieldset>
-            <fieldset class="col-sm-5" *ngIf="moduleType == 'native'">
-                <label>Image</label>
-                <input class="form-control" type="text" [(ngModel)]="newNativeModule.image" throttle required />
-            </fieldset>
+            </div>            
         </div>
     `
 })

--- a/src/app/webserver/request-filtering/file-extensions.component.ts
+++ b/src/app/webserver/request-filtering/file-extensions.component.ts
@@ -177,7 +177,7 @@ export class FileExtensionComponent implements OnInit, OnChanges {
                     <file-extension [model]="fe" [locked]="locked" (enter)="onEnter()" (leave)="onLeave()"></file-extension>
                 </li>
             </ul>
-        </div> 
+        </div>
     `
 })
 export class FileExtensionsComponent implements OnInit, OnDestroy {

--- a/src/app/webserver/request-filtering/file-extensions.component.ts
+++ b/src/app/webserver/request-filtering/file-extensions.component.ts
@@ -12,6 +12,25 @@ import { RequestFilteringService } from './request-filtering.service';
     template: `
         <div *ngIf="model" class="grid-item row" [class.background-editing]="_editing">
 
+            <fieldset class="col-xs-8 col-sm-4">
+                <label class="visible-xs">Extension</label>
+                <label class="hidden-xs" [hidden]="!_editing">Extension</label>
+                <i class="fa fa-circle green hidden-xs" *ngIf="model.allow && !_editing"></i>
+                <i class="fa fa-ban red hidden-xs" *ngIf="!model.allow && !_editing"></i>
+                <input autofocus class="form-control" *ngIf="_editing" type="text" [disabled]="locked" [(ngModel)]="model.extension" throttle required />
+                <span *ngIf="!_editing">{{model.extension}}</span>
+                <div *ngIf="!_editing">
+                    <br class="visible-xs" />
+                </div>
+            </fieldset>
+
+            <fieldset class="col-xs-12 col-sm-4">
+                <label class="visible-xs">Allowed</label>
+                <label class="hidden-xs" [hidden]="!_editing">Allowed</label>
+                <span *ngIf="!_editing">{{model.allow ? "Allow" : "Deny"}}</span>
+                <switch class="block" *ngIf="_editing" [disabled]="locked" [(model)]="model.allow">{{model.allow ? "Allow" : "Deny"}}</switch>
+            </fieldset>
+
             <div class="actions">
                 <button class="no-border" *ngIf="!_editing" [class.inactive]="!_editable" title="Edit" (click)="onEdit()">
                     <i class="fa fa-pencil color-active"></i>
@@ -26,25 +45,6 @@ import { RequestFilteringService } from './request-filtering.service';
                     <i class="fa fa-trash-o red"></i>
                 </button>
             </div>
-
-            <fieldset class="col-xs-8 col-sm-4">
-                <label class="visible-xs">Extension</label>
-                <label class="hidden-xs" [hidden]="!_editing">Extension</label>
-                <i class="fa fa-circle green hidden-xs" *ngIf="model.allow && !_editing"></i>
-                <i class="fa fa-ban red hidden-xs" *ngIf="!model.allow && !_editing"></i>
-                <input class="form-control" *ngIf="_editing" type="text" [disabled]="locked" [(ngModel)]="model.extension" throttle required />
-                <span *ngIf="!_editing">{{model.extension}}</span>
-                <div *ngIf="!_editing">
-                    <br class="visible-xs" />
-                </div>
-            </fieldset>
-
-            <fieldset class="col-xs-12 col-sm-4">
-                <label class="visible-xs">Allowed</label>
-                <label class="hidden-xs" [hidden]="!_editing">Allowed</label>
-                <span *ngIf="!_editing">{{model.allow ? "Allow" : "Deny"}}</span>
-                <switch class="block" *ngIf="_editing" [disabled]="locked" [(model)]="model.allow">{{model.allow ? "Allow" : "Deny"}}</switch>
-            </fieldset>
 
         </div>
     `,

--- a/src/app/webserver/request-filtering/request-filtering.module.ts
+++ b/src/app/webserver/request-filtering/request-filtering.module.ts
@@ -10,6 +10,7 @@ import { Module as OverrideMode } from '../../common/override-mode.component';
 import { Module as StringList } from '../../common/string-list.component';
 import { Module as ErrorComponent } from '../../error/error.component';
 import { Module as Tabs } from '../../common/tabs.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { RequestFilteringService } from './request-filtering.service';
 
@@ -28,7 +29,8 @@ import { RulesComponent, RuleComponent } from './rules.component';
         OverrideMode,
         StringList,
         ErrorComponent,
-        Tabs
+        Tabs,
+        AutoFocus,
     ],
     declarations: [
         FileExtensionsComponent,

--- a/src/app/webserver/request-filtering/rules.component.ts
+++ b/src/app/webserver/request-filtering/rules.component.ts
@@ -279,7 +279,7 @@ export class RuleComponent implements OnInit, OnChanges {
                     <rule [model]="r" [locked]="locked" (enter)="enterRule(i)" (leave)="leaveRule(i)"></rule>
                 </li>                
             </ul>
-        </div>  
+        </div>
     `,
 })
 export class RulesComponent implements OnInit, OnDestroy {

--- a/src/app/webserver/request-filtering/rules.component.ts
+++ b/src/app/webserver/request-filtering/rules.component.ts
@@ -277,7 +277,7 @@ export class RuleComponent implements OnInit, OnChanges {
                 </li>
                 <li *ngFor="let r of rules; let i = index;">
                     <rule [model]="r" [locked]="locked" (enter)="enterRule(i)" (leave)="leaveRule(i)"></rule>
-                </li>                
+                </li>
             </ul>
         </div>
     `,

--- a/src/app/webserver/request-filtering/rules.component.ts
+++ b/src/app/webserver/request-filtering/rules.component.ts
@@ -12,20 +12,6 @@ import { RequestFilteringService } from './request-filtering.service';
     selector: 'rule',
     template: `
         <div *ngIf="model" class="grid-item row" [class.background-editing]="_editing">
-            <div class="actions">
-                <button class="no-border no-editing" [class.inactive]="!_editable" title="Edit" (click)="onEdit()">
-                    <i class="fa fa-pencil color-active"></i>
-                </button>
-                <button class="no-border editing" [disabled]="!isValid() || locked" title="Ok" (click)="onSave()">
-                    <i class="fa fa-check color-active"></i>
-                </button>
-                <button class="no-border editing" title="Cancel" (click)="onDiscard()">
-                    <i class="fa fa-times red"></i>
-                </button>
-                <button class="no-border" *ngIf="model.id" [disabled]="locked" title="Delete" [class.inactive]="!_editable" (click)="onDelete()">
-                    <i class="fa fa-trash-o red"></i>
-                </button>
-            </div>
 
             <fieldset class="col-xs-8 col-sm-3" *ngIf="!_editing">
                 <label class="visible-xs">Name</label>
@@ -37,7 +23,7 @@ import { RequestFilteringService } from './request-filtering.service';
 
             <fieldset class="col-xs-8 col-md-9 col-lg-10" *ngIf="_editing">
                 <label class="block">Name</label>
-                <input class="form-control" type="text" [disabled]="locked" [(ngModel)]="model.name" throttle required />
+                <input autofocus class="form-control" type="text" [disabled]="locked" [(ngModel)]="model.name" throttle required />
             </fieldset>
 
             <fieldset class="col-xs-8 col-sm-5 col-md-6" *ngIf="!_editing">
@@ -94,6 +80,22 @@ import { RequestFilteringService } from './request-filtering.service';
                 </div>
 
             </div>
+
+            <div class="actions">
+                <button class="no-border no-editing" [class.inactive]="!_editable" title="Edit" (click)="onEdit()">
+                    <i class="fa fa-pencil color-active"></i>
+                </button>
+                <button class="no-border editing" [disabled]="!isValid() || locked" title="Ok" (click)="onSave()">
+                    <i class="fa fa-check color-active"></i>
+                </button>
+                <button class="no-border editing" title="Cancel" (click)="onDiscard()">
+                    <i class="fa fa-times red"></i>
+                </button>
+                <button class="no-border" *ngIf="model.id" [disabled]="locked" title="Delete" [class.inactive]="!_editable" (click)="onDelete()">
+                    <i class="fa fa-trash-o red"></i>
+                </button>
+            </div>
+
         </div>
     `,
     styles: [`

--- a/src/app/webserver/request-tracing/provider.component.ts
+++ b/src/app/webserver/request-tracing/provider.component.ts
@@ -15,7 +15,7 @@ import {RequestTracingService} from './request-tracing.service';
             <fieldset class="col-xs-8" *ngIf="!_isEditing">
                 <span>{{model.name}}</span>
             </fieldset>
-            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible" *ngIf="_isEditing">
+            <div class="col-lg-10 col-md-10 col-sm-8 col-xs-8 overflow-visible" *ngIf="_isEditing">
                 <fieldset>
                     <label>Name</label>
                     <input autofocus class="form-control name" type="text" [(ngModel)]="model.name" required throttle/>

--- a/src/app/webserver/request-tracing/provider.component.ts
+++ b/src/app/webserver/request-tracing/provider.component.ts
@@ -11,7 +11,25 @@ import {RequestTracingService} from './request-tracing.service';
 @Component({
     selector: 'provider',
     template: `
-        <div *ngIf="model" class="grid-item row" [class.background-editing]="_isEditing">
+        <div *ngIf="model" class="row grid-item" [class.background-editing]="_isEditing">
+            <fieldset class="col-xs-8" *ngIf="!_isEditing">
+                <span>{{model.name}}</span>
+            </fieldset>
+            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible" *ngIf="_isEditing">
+                <fieldset>
+                    <label>Name</label>
+                    <input autofocus class="form-control name" type="text" [(ngModel)]="model.name" required throttle/>
+                </fieldset>
+                <fieldset class="name" >
+                    <label>Guid</label>
+                    <input *ngIf="!model.id" class="form-control" type="text" [(ngModel)]="model.guid" required pattern="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" throttle/>
+                    <span *ngIf="model.id" class="editing form-control">{{model.guid}}</span>
+                </fieldset>
+                <fieldset>
+                    <button (click)="areas.add()" class="background-normal" ><i class="fa fa-plus color-active" ></i><span>Add Area</span></button>
+                </fieldset>
+                <string-list class="name"  #areas="stringList" [(model)]="model.areas"></string-list>
+            </div>
             <div class="actions">
                 <button class="no-border no-editing" [class.inactive]="readonly" title="Edit" (click)="onEdit()">
                     <i class="fa fa-pencil color-active"></i>
@@ -25,22 +43,6 @@ import {RequestTracingService} from './request-tracing.service';
                 <button class="no-border" *ngIf="model.id" title="Delete" [class.inactive]="readonly" (click)="onDelete()">
                     <i class="fa fa-trash-o red"></i>
                 </button>
-            </div>
-            <fieldset>
-                <label [hidden]="!_isEditing">Name</label>
-                <input class="form-control name" *ngIf="_isEditing" type="text" [(ngModel)]="model.name" required throttle/>
-                <span>{{model.name}}</span>
-            </fieldset>
-            <fieldset class="name" *ngIf="_isEditing">
-                <label>Guid</label>
-                <input *ngIf="!model.id" class="form-control" type="text" [(ngModel)]="model.guid" required pattern="[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$" throttle/>
-                <span *ngIf="model.id" class="editing form-control">{{model.guid}}</span>
-            </fieldset>
-            <div *ngIf="_isEditing">
-                <fieldset>
-                    <button (click)="areas.add()" class="background-normal" ><i class="fa fa-plus color-active" ></i><span>Add Area</span></button>
-                </fieldset>
-                <string-list class="name"  #areas="stringList" [(model)]="model.areas"></string-list>
             </div>
         </div>
     `,

--- a/src/app/webserver/request-tracing/request-tracing.component.ts
+++ b/src/app/webserver/request-tracing/request-tracing.component.ts
@@ -43,10 +43,8 @@ import { RequestTracing, RequestTracingRule, Trace, EventSeverity, Verbosity } f
                 <tab [name]="'settings'" *ngIf="scopeType() == 'website'">
                     <fieldset class="path">
                         <label>Directory</label>
-                        <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="right select" (click)="fileSelector.toggle()"></button>
-                        <div class="fill">
-                            <input type="text" class="form-control" [(ngModel)]="requestTracing.directory" (modelChanged)="onModelChanged()" throttle />
-                        </div>
+                        <input type="text" class="form-control left-with-button" [(ngModel)]="requestTracing.directory" (modelChanged)="onModelChanged()" throttle />
+                        <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
                         <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="requestTracing.directory" (selected)="onSelectPath($event)"></server-file-selector>
                     </fieldset>
                     <fieldset>

--- a/src/app/webserver/request-tracing/request-tracing.module.ts
+++ b/src/app/webserver/request-tracing/request-tracing.module.ts
@@ -19,6 +19,7 @@ import { Module as Selectable } from '../../common/selectable';
 import { Module as Toolbar } from '../../files/toolbar.component';
 import { Module as Warning } from '../../notification/warning.component';
 import { Module as Tabs } from '../../common/tabs.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { FilesModule } from '../../files/files.module';
 
@@ -53,7 +54,8 @@ import { TraceFileComponent } from './trace-file.component';
         Toolbar,
         Warning,
         Tabs,
-        FilesModule
+        FilesModule,
+        AutoFocus,
     ],
     declarations: [
         ProvidersComponent,

--- a/src/app/webserver/request-tracing/rule.component.ts
+++ b/src/app/webserver/request-tracing/rule.component.ts
@@ -67,7 +67,7 @@ import { RequestTracingService } from './request-tracing.service';
                         </div>
                     </fieldset>
                 </div>
-            </div>            
+            </div>
             <div class="actions">
                 <button class="no-border no-editing" [class.inactive]="readonly" title="Edit" (click)="onEdit()">
                     <i class="fa fa-pencil color-active"></i>

--- a/src/app/webserver/request-tracing/rule.component.ts
+++ b/src/app/webserver/request-tracing/rule.component.ts
@@ -12,6 +12,62 @@ import { RequestTracingService } from './request-tracing.service';
     selector: 'rule',
     template: `
         <div *ngIf="model" class="grid-item row" [class.background-editing]="_isEditing">
+            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible">
+                <fieldset class="col-xs-8 col-sm-4 col-md-3" *ngIf="!_isEditing">
+                    <span>{{model.path}}</span>
+                </fieldset>
+                <fieldset class="col-xs-9" *ngIf="_isEditing">
+                    <label>Path</label>
+                    <input autofocus autosize placeholder="Example: *.aspx" class="form-control" type="text" [(ngModel)]="model.path" throttle required />
+                </fieldset>
+                <fieldset class="hidden-xs col-sm-3 col-md-3 col-lg-2" *ngIf="!_isEditing">
+                    <span>{{model.status_codes.join(", ")}}</span>
+                </fieldset>
+                <fieldset class="hidden-xs hidden-sm col-md-3 col-lg-2" *ngIf="!_isEditing">
+                    <span *ngIf="hasMinReqExecutionTime()">{{model.min_request_execution_time}}</span>
+                </fieldset>
+                <fieldset class="hidden-xs hidden-sm hidden-md col-lg-2" *ngIf="!_isEditing">
+                    <span *ngIf="model.event_severity != 'ignore'">{{friendlyEventSeverity(model.event_severity)}}</span>
+                </fieldset>
+                <div *ngIf="_isEditing" id="statusCodes" class="col-xs-12">
+                    <fieldset class="inline-block has-list">
+                        <label>Status Code(s)</label>
+                    </fieldset>
+                    <button class="pull-right background-normal" *ngIf="!!(!(statusCodes && statusCodes.list) && model.status_codes.length > 0 || statusCodes.list && statusCodes.list.length> 0)" (click)="statusCodes.add()" ><i class="fa fa-plus color-active" ></i><span>Add</span></button>
+                    <fieldset>
+                        <string-list #statusCodes="stringList" [(model)]="model.status_codes"></string-list>
+                        <button class="background-normal" *ngIf="statusCodes.list.length == 0" (click)="statusCodes.add()"><i class="fa fa-plus color-active"></i><span>Add</span></button>
+                    </fieldset>
+                </div>
+                <fieldset *ngIf="_isEditing" class="col-xs-12">
+                    <fieldset class="inline-block"> 
+                        <label class="block">Min Request Time</label>
+                        <switch [model]="hasMinReqExecutionTime()" (modelChange)="enableRequestTime($event)">{{hasMinReqExecutionTime() ? "On" : "Off"}}</switch>
+                    </fieldset>
+                    <fieldset class="inline-block" *ngIf="hasMinReqExecutionTime()">
+                        <label class="block">Length <span class="units">(s)</span></label>
+                        <input class="form-control" type="number" [(ngModel)]="model.min_request_execution_time" throttle />
+                    </fieldset>
+                </fieldset>
+                <fieldset *ngIf="_isEditing" class="col-xs-12">
+                    <label>Event Severity</label>
+                    <enum [(model)]="model.event_severity">
+                        <field name="Any" value="ignore"></field>
+                        <field name="Critical Error" value="criticalerror"></field>
+                        <field name="Error" value="error"></field>
+                        <field name="Warning" value="warning"></field>
+                    </enum>
+                </fieldset>
+                <div *ngIf="_isEditing" class="col-xs-12 col-sm-12 col-md-7 col-lg-6">
+                    <fieldset *ngFor="let p of _providers;">
+                        <label>{{p.name}}</label>
+                        <switch class="block" [model]="isProviderEnabled(p)" (modelChange)="enableProvider(p, $event)"></switch>
+                        <div class="trace" *ngIf="isProviderEnabled(p)">
+                            <trace [model]="getTrace(p)"></trace>
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
             <div class="actions">
                 <button class="no-border no-editing" [class.inactive]="readonly" title="Edit" (click)="onEdit()">
                     <i class="fa fa-pencil color-active"></i>
@@ -25,60 +81,6 @@ import { RequestTracingService } from './request-tracing.service';
                 <button class="no-border" *ngIf="model.id" title="Delete" [class.inactive]="readonly" (click)="onDelete()">
                     <i class="fa fa-trash-o red"></i>
                 </button>
-            </div>
-            <fieldset class="col-xs-8 col-sm-4 col-md-3" *ngIf="!_isEditing">
-                <span>{{model.path}}</span>
-            </fieldset>
-            <fieldset class="col-xs-9" *ngIf="_isEditing">
-                <label>Path</label>
-                <input autosize placeholder="Example: *.aspx" class="form-control" type="text" [(ngModel)]="model.path" throttle required />
-            </fieldset>
-            <fieldset class="hidden-xs col-sm-3 col-md-3 col-lg-2" *ngIf="!_isEditing">
-                <span>{{model.status_codes.join(", ")}}</span>
-            </fieldset>
-            <fieldset class="hidden-xs hidden-sm col-md-3 col-lg-2" *ngIf="!_isEditing">
-                <span *ngIf="hasMinReqExecutionTime()">{{model.min_request_execution_time}}</span>
-            </fieldset>
-            <fieldset class="hidden-xs hidden-sm hidden-md col-lg-2" *ngIf="!_isEditing">
-                <span *ngIf="model.event_severity != 'ignore'">{{friendlyEventSeverity(model.event_severity)}}</span>
-            </fieldset>
-            <div *ngIf="_isEditing" id="statusCodes" class="col-xs-12">
-                <fieldset class="inline-block has-list">
-                    <label>Status Code(s)</label>
-                </fieldset>
-                <button class="pull-right background-normal" *ngIf="!!(!(statusCodes && statusCodes.list) && model.status_codes.length > 0 || statusCodes.list && statusCodes.list.length> 0)" (click)="statusCodes.add()" ><i class="fa fa-plus color-active" ></i><span>Add</span></button>
-                <fieldset>
-                    <string-list #statusCodes="stringList" [(model)]="model.status_codes"></string-list>
-                    <button class="background-normal" *ngIf="statusCodes.list.length == 0" (click)="statusCodes.add()"><i class="fa fa-plus color-active"></i><span>Add</span></button>
-                </fieldset>
-            </div>
-            <fieldset *ngIf="_isEditing" class="col-xs-12">
-                <fieldset class="inline-block"> 
-                    <label class="block">Min Request Time</label>
-                    <switch [model]="hasMinReqExecutionTime()" (modelChange)="enableRequestTime($event)">{{hasMinReqExecutionTime() ? "On" : "Off"}}</switch>
-                </fieldset>
-                <fieldset class="inline-block" *ngIf="hasMinReqExecutionTime()">
-                    <label class="block">Length <span class="units">(s)</span></label>
-                    <input class="form-control" type="number" [(ngModel)]="model.min_request_execution_time" throttle />
-                </fieldset>
-            </fieldset>
-            <fieldset *ngIf="_isEditing" class="col-xs-12">
-                <label>Event Severity</label>
-                <enum [(model)]="model.event_severity">
-                    <field name="Any" value="ignore"></field>
-                    <field name="Critical Error" value="criticalerror"></field>
-                    <field name="Error" value="error"></field>
-                    <field name="Warning" value="warning"></field>
-                </enum>
-            </fieldset>
-            <div *ngIf="_isEditing" class="col-xs-12 col-sm-12 col-md-7 col-lg-6">
-                <fieldset *ngFor="let p of _providers;">
-                    <label>{{p.name}}</label>
-                    <switch class="block" [model]="isProviderEnabled(p)" (modelChange)="enableProvider(p, $event)"></switch>
-                    <div class="trace" *ngIf="isProviderEnabled(p)">
-                        <trace [model]="getTrace(p)"></trace>
-                    </div>
-                </fieldset>
             </div>
         </div>
     `,

--- a/src/app/webserver/request-tracing/rule.component.ts
+++ b/src/app/webserver/request-tracing/rule.component.ts
@@ -12,7 +12,7 @@ import { RequestTracingService } from './request-tracing.service';
     selector: 'rule',
     template: `
         <div *ngIf="model" class="grid-item row" [class.background-editing]="_isEditing">
-            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible">
+            <div [class]="_isEditing ? 'col-lg-10 col-md-10 col-sm-10 overflow-visible' : ''">
                 <fieldset class="col-xs-8 col-sm-4 col-md-3" *ngIf="!_isEditing">
                     <span>{{model.path}}</span>
                 </fieldset>
@@ -67,7 +67,7 @@ import { RequestTracingService } from './request-tracing.service';
                         </div>
                     </fieldset>
                 </div>
-            </div>
+            </div>            
             <div class="actions">
                 <button class="no-border no-editing" [class.inactive]="readonly" title="Edit" (click)="onEdit()">
                     <i class="fa fa-pencil color-active"></i>

--- a/src/app/webserver/request-tracing/trace-file.component.ts
+++ b/src/app/webserver/request-tracing/trace-file.component.ts
@@ -13,7 +13,7 @@ import { FilesService } from '../../files/files.service';
     template: `
         <div *ngIf="model" class="grid-item row" tabindex="-1">
             <div class="col-xs-8 col-sm-3 col-lg-2 valign" [ngClass]="[model.file_info.type, model.file_info.extension]">
-                    <a class="color-normal hover-color-active" [href]="url" (click)="onClickName($event)"><i></i>{{model.file_info.name}}</a>
+                <a class="color-normal hover-color-active" [href]="url" (click)="onClickName($event)"><i></i>{{model.file_info.name}}</a>
             </div>
             <div class="col-sm-4 col-lg-3 hidden-xs valign support">
                 <span *ngIf="model.url">{{model.url}}</span>

--- a/src/app/webserver/request-tracing/trace.component.ts
+++ b/src/app/webserver/request-tracing/trace.component.ts
@@ -22,7 +22,7 @@ import {Provider, Trace} from './request-tracing';
             <fieldset class="inline-block" *ngIf="getKeys(model.allowed_areas).length > 0">
                 <label>Areas</label>
                 <ul>
-                    <li *ngFor="let area of getKeys(model.allowed_areas)">                        
+                    <li *ngFor="let area of getKeys(model.allowed_areas)">
                         <checkbox2 [(model)]="model.allowed_areas[area]"><span>{{area}}</span></checkbox2>
                     </li>
                 </ul>

--- a/src/app/webserver/url-rewrite/inbound-rules/inbound-rule-conditions.ts
+++ b/src/app/webserver/url-rewrite/inbound-rules/inbound-rule-conditions.ts
@@ -140,25 +140,27 @@ export class InboundRuleConditionComponent {
     selector: 'condition-edit',
     template: `
         <div *ngIf="condition" class="grid-item row background-editing">
+            <fieldset class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
+                <fieldset class="name">
+                    <label>Server Variable</label>
+                    <input autofocus type="text" required class="form-control" list="server-vars" [(ngModel)]="condition.input" />
+                    <datalist id="server-vars">
+                        <option *ngFor="let variable of _serverVariables" value="{{'{' + variable + '}'}}">
+                    </datalist>
+                </fieldset>
+                <fieldset class="name">
+                    <div>
+                        <label class="inline-block">Pattern</label>
+                        <text-toggle onText="Matches" offText="Doesn't Match" [on]="false" [off]="true" [(model)]="condition.negate"></text-toggle>
+                        <text-toggle onText="Case Insensitive" offText="Case Sensitive" [(model)]="condition.ignore_case"></text-toggle>
+                    </div>
+                    <input type="text" required class="form-control" [(ngModel)]="condition.pattern" />
+                </fieldset>
+            </fieldset>
             <div class="actions">
                 <button class="no-border ok" [disabled]="!isValid()" title="Ok" (click)="onOk()"></button>
                 <button class="no-border cancel" title="Cancel" (click)="onDiscard()"></button>
             </div>
-            <fieldset class="name">
-                <label>Server Variable</label>
-                <input type="text" required class="form-control" list="server-vars" [(ngModel)]="condition.input" />
-                <datalist id="server-vars">
-                    <option *ngFor="let variable of _serverVariables" value="{{'{' + variable + '}'}}">
-                </datalist>
-            </fieldset>
-            <fieldset class="name">
-                <div>
-                    <label class="inline-block">Pattern</label>
-                    <text-toggle onText="Matches" offText="Doesn't Match" [on]="false" [off]="true" [(model)]="condition.negate"></text-toggle>
-                    <text-toggle onText="Case Insensitive" offText="Case Sensitive" [(model)]="condition.ignore_case"></text-toggle>
-                </div>
-                <input type="text" required class="form-control" [(ngModel)]="condition.pattern" />
-            </fieldset>
         </div>
     `,
     styles: [`

--- a/src/app/webserver/url-rewrite/inbound-rules/inbound-rule-settings.ts
+++ b/src/app/webserver/url-rewrite/inbound-rules/inbound-rule-settings.ts
@@ -5,64 +5,72 @@ import { InboundRule, IIS_SERVER_VARIABLES } from '../url-rewrite';
 @Component({
     selector: 'inbound-rule-settings',
     template: `
-        <div class="row" *ngIf="rule">
-            <div class="col-xs-12 col-lg-6">
-                <fieldset>
-                    <label>Name</label>
-                    <input type="text" class="form-control" required [(ngModel)]="rule.name" />
-                </fieldset>
-                <fieldset>
-                    <div>
-                        <label class="inline-block">Url Pattern</label>
-                        <tooltip>
-                            This pattern is compared to the URL of the incoming request to determine if the rule matches.
-                            <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/url-rewrite-module-configuration-reference" class="link"></a>
-                        </tooltip>
-                        <text-toggle onText="Match" offText="No Match" [on]="false" [off]="true" [(model)]="rule.negate" (modelChanged)="testRegex()"></text-toggle>
-                        <text-toggle onText="Case Insensitive" offText="Case Sensitive" [(model)]="rule.ignore_case" (modelChanged)="testRegex()"></text-toggle>
-                    </div>
-                    <input type="text" class="form-control" required [(ngModel)]="rule.pattern" (modelChanged)="testRegex()" />
-                </fieldset>
-                <fieldset>
-                    <label class="inline-block">Test Url</label>
+    <div class="row" *ngIf="rule">
+        <div class="col-xs-12 col-lg-6">
+            <fieldset>
+                <label>Name</label>
+                <input autofocus type="text" class="form-control" required [(ngModel)]="rule.name" />
+            </fieldset>
+            <fieldset>
+                <div>
+                    <label class="inline-block">Url Pattern</label>
                     <tooltip>
-                        This field can be used to test the matching behavior of the Url Pattern.
+                        This pattern is compared to the URL of the incoming request to determine if the rule matches.
+                        <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/url-rewrite-module-configuration-reference" class="link"></a>
                     </tooltip>
-                    <span class="units" *ngIf="_testUrl && !_isMatching">(Doesn't Match)</span>
-                    <input type="text" class="form-control" [(ngModel)]="_testUrl" (modelChanged)="testRegex()" />
-                </fieldset>
-                <fieldset *ngIf="rule.action.type == 'rewrite' || rule.action.type == 'redirect'">
-                    <div>
-                        <label class="inline-block">Substitution Url</label>
-                        <tooltip>
-                            This is the substitution string to use when rewriting the request URL. The substitution URL can include back-references to conditions and the URL pattern as well as server variables.
-                            <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/url-rewrite-module-configuration-reference" class="link"></a>
-                        </tooltip>
+                    <text-toggle onText="Match" offText="No Match" [on]="false" [off]="true" [(model)]="rule.negate" (modelChanged)="testRegex()"></text-toggle>
+                    <text-toggle onText="Case Insensitive" offText="Case Sensitive" [(model)]="rule.ignore_case" (modelChanged)="testRegex()"></text-toggle>
+                </div>
+                <input type="text" class="form-control" required [(ngModel)]="rule.pattern" (modelChanged)="testRegex()" />
+            </fieldset>
+            <fieldset>
+                <label class="inline-block">Test Url</label>
+                <tooltip>
+                    This field can be used to test the matching behavior of the Url Pattern.
+                </tooltip>
+                <span class="units" *ngIf="_testUrl && !_isMatching">(Doesn't Match)</span>
+                <input type="text" class="form-control" [(ngModel)]="_testUrl" (modelChanged)="testRegex()" />
+            </fieldset>
+            <fieldset *ngIf="rule.action.type == 'rewrite' || rule.action.type == 'redirect'">
+                <div>
+                    <label class="inline-block">Substitution Url</label>
+                    <tooltip>
+                        This is the substitution string to use when rewriting the request URL. The substitution URL can include back-references to conditions and the URL pattern as well as server variables.
+                        <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/url-rewrite-module-configuration-reference" class="link"></a>
+                    </tooltip>
+                </div>
+                <input type="text" required [title]="_result" class="form-control left-with-button" [(ngModel)]="rule.action.url" (modelChanged)="testRegex()" />
+                <button class="input" (click)="macros.toggle()" [class.background-active]="(macros && macros.opened) || false">Macros</button>
+                <selector class="stretch" #macros>
+                    <div class="table-scroll">
+                        <table>
+                            <tr *ngFor="let match of _matches; let i = index;" (dblclick)="addMatch(i)" (click)="select(i)" class="hover-editing" [class.background-selected]="_selected == i">
+                                <td class="back-ref border-color">{{ '{R:' + i + '}' }}</td>
+                                <td class="border-color">{{match}}</td>
+                            </tr>
+                            <tr *ngFor="let variable of _serverVariables; let i = index;" 
+                                (keyup.esc)="macros.toggle()" 
+                                (keyup.enter)="addVariable(i)" 
+                                (dblclick)="addVariable(i)" 
+                                (click)="select(i + _matches.length)"
+                                (keyup.space)="select(i + _matches.length)" 
+                                class="hover-editing" 
+                                [class.background-selected]="_selected == (i + _matches.length)">
+
+                                <td class="back-ref border-color">
+                                    <span tabindex="0">{{ '{' + variable + '}' }}</span>
+                                </td>
+                                <td class="border-color"></td>
+                            </tr>
+                        </table>
                     </div>
-                    <button class="right input" (click)="macros.toggle()" [class.background-active]="(macros && macros.opened) || false">Macros</button>
-                    <div class="fill">
-                        <input type="text" required [title]="_result" class="form-control" [(ngModel)]="rule.action.url" (modelChanged)="testRegex()" />
-                    </div>
-                    <selector class="stretch" #macros>
-                        <div class="table-scroll">
-                            <table>
-                                <tr *ngFor="let match of _matches; let i = index;" (dblclick)="addMatch(i)" (click)="select(i)" class="hover-editing" [class.background-selected]="_selected == i">
-                                    <td class="back-ref border-color">{{ '{R:' + i + '}' }}</td>
-                                    <td class="border-color">{{match}}</td>
-                                </tr>
-                                <tr *ngFor="let variable of _serverVariables; let i = index;" (dblclick)="addVariable(i)" (click)="select(i + _matches.length)" class="hover-editing" [class.background-selected]="_selected == (i + _matches.length)">
-                                    <td class="back-ref border-color">{{ '{' + variable + '}' }}</td>
-                                    <td class="border-color"></td>
-                                </tr>
-                            </table>
-                        </div>
-                        <p class="pull-right">
-                            <button [attr.disabled]="_selected == -1 || null" (click)="addSelected()">Insert</button>
-                        </p>
-                    </selector>
-                </fieldset>
-            </div>
+                    <p class="pull-right">
+                        <button [attr.disabled]="_selected == -1 || null" (click)="addSelected()">Insert</button>
+                    </p>
+                </selector>
+            </fieldset>
         </div>
+    </div>
     `,
     styles: [`
         table {
@@ -83,6 +91,14 @@ import { InboundRule, IIS_SERVER_VARIABLES } from '../url-rewrite';
             border-width: 1px;
             padding: 5px;
             border-top: none;
+        }
+
+        span:focus {
+            outline-style: dashed;
+            outline-color: #000;
+            outline-width: 2px;
+            outline-offset: -2px;
+            text-decoration: underline;
         }
 
         .back-ref {

--- a/src/app/webserver/url-rewrite/inbound-rules/inbound-rule-variables.ts
+++ b/src/app/webserver/url-rewrite/inbound-rules/inbound-rule-variables.ts
@@ -114,25 +114,27 @@ export class InboundRuleVariableComponent {
     selector: 'variable-edit',
     template: `
         <div *ngIf="variable" class="grid-item row background-editing">
+            <fieldset class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
+                <fieldset class="name">
+                    <label>Name</label>
+                    <input autofocus type="text" required class="form-control" list="server-vars" [(ngModel)]="variable.name" />
+                    <datalist id="server-vars">
+                        <option *ngFor="let variable of _serverVariables" value="{{variable}}">
+                    </datalist>
+                </fieldset>
+                <fieldset class="name">
+                    <label>Value</label>
+                    <input type="text" required class="form-control" [(ngModel)]="variable.value" />
+                </fieldset>
+                <fieldset>
+                    <label>Replace</label>
+                    <switch [(model)]="variable.replace">{{variable.replace ? 'Yes' : 'No'}}</switch>
+                </fieldset>
+            </fieldset>
             <div class="actions">
                 <button class="no-border ok" [disabled]="!isValid()" title="Ok" (click)="onOk()"></button>
                 <button class="no-border cancel" title="Cancel" (click)="onDiscard()"></button>
             </div>
-            <fieldset class="name">
-                <label>Name</label>
-                <input type="text" required class="form-control" list="server-vars" [(ngModel)]="variable.name" />
-                <datalist id="server-vars">
-                    <option *ngFor="let variable of _serverVariables" value="{{variable}}">
-                </datalist>
-            </fieldset>
-            <fieldset class="name">
-                <label>Value</label>
-                <input type="text" required class="form-control" [(ngModel)]="variable.value" />
-            </fieldset>
-            <fieldset>
-                <label>Replace</label>
-                <switch [(model)]="variable.replace">{{variable.replace ? 'Yes' : 'No'}}</switch>
-            </fieldset>
         </div>
     `,
     styles: [`

--- a/src/app/webserver/url-rewrite/inbound-rules/inbound-rules.component.ts
+++ b/src/app/webserver/url-rewrite/inbound-rules/inbound-rules.component.ts
@@ -24,7 +24,7 @@ import { InboundSection, InboundRule, PatternSyntax, ActionType, ConditionMatchC
                 
                 <button class="create" [class.background-active]="newRule.opened" (click)="newRule.toggle()">Create Rule <i class="fa fa-caret-down"></i></button>
                 <selector #newRule class="container-fluid create" (hide)="initializeNewRule()">
-                    <inbound-rule-edit [rule]="_newRule" (save)="saveNew($event)" (cancel)="newRule.close()"></inbound-rule-edit>
+                    <inbound-rule-edit *ngIf="newRule.opened" [rule]="_newRule" (save)="saveNew($event)" (cancel)="newRule.close()"></inbound-rule-edit>
                 </selector>
             </div>
 

--- a/src/app/webserver/url-rewrite/outbound-rules/outbound-rule-settings.ts
+++ b/src/app/webserver/url-rewrite/outbound-rules/outbound-rule-settings.ts
@@ -5,65 +5,78 @@ import { OutboundRule, IIS_SERVER_VARIABLES } from '../url-rewrite';
 @Component({
     selector: 'outbound-rule-settings',
     template: `
-        <div class="row" *ngIf="rule">
-            <div class="col-xs-12 col-lg-6">
-                <fieldset>
-                    <label>Name</label>
-                    <input type="text" required class="form-control" [(ngModel)]="rule.name" />
-                </fieldset>
-                <fieldset>
-                    <div>
-                        <label class="inline-block">Pattern</label>
-                        <tooltip>
-                            This pattern is compared to either the response body or a server variable to determine if the rule matches.
-                            <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/creating-outbound-rules-for-url-rewrite-module" class="link"></a>
-                        </tooltip>
-                        <text-toggle onText="Matches" offText="Doesn't Match" [on]="false" [off]="true" [(model)]="rule.negate" (modelChanged)="testRegex()"></text-toggle>
-                        <text-toggle onText="Case Insensitive" offText="Case Sensitive" [(model)]="rule.ignore_case" (modelChanged)="testRegex()"></text-toggle>
-                    </div>
-                    <input type="text" required class="form-control" [(ngModel)]="rule.pattern" (modelChanged)="testRegex()" />
-                </fieldset>
-                <fieldset>
-                    <label class="inline-block">Test Value</label>
+    <div class="row" *ngIf="rule">
+        <div class="col-xs-12 col-lg-6">
+            <fieldset>
+                <label>Name</label>
+                <input autofocus type="text" required class="form-control" [(ngModel)]="rule.name" />
+            </fieldset>
+            <fieldset>
+                <div>
+                    <label class="inline-block">Pattern</label>
                     <tooltip>
-                        This field can be used to test the matching behavior of the rule pattern.
+                        This pattern is compared to either the response body or a server variable to determine if the rule matches.
+                        <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/creating-outbound-rules-for-url-rewrite-module" class="link"></a>
                     </tooltip>
-                    <input type="text" class="form-control" [(ngModel)]="_testUrl" (modelChanged)="testRegex()" />
-                </fieldset>
-                <fieldset>
-                    <div>
-                        <label>Substitution Value</label>
-                        <tooltip>
-                            This is the substitution string to use when rewriting the response. The substitution value can include back-references to conditions and the rule pattern as well as server variables.
-                            <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/creating-outbound-rules-for-url-rewrite-module" class="link"></a>
-                        </tooltip>
+                    <text-toggle onText="Matches" offText="Doesn't Match" [on]="false" [off]="true" [(model)]="rule.negate" (modelChanged)="testRegex()"></text-toggle>
+                    <text-toggle onText="Case Insensitive" offText="Case Sensitive" [(model)]="rule.ignore_case" (modelChanged)="testRegex()"></text-toggle>
+                </div>
+                <input type="text" required class="form-control" [(ngModel)]="rule.pattern" (modelChanged)="testRegex()" />
+            </fieldset>
+            <fieldset>
+                <label class="inline-block">Test Value</label>
+                <tooltip>
+                    This field can be used to test the matching behavior of the rule pattern.
+                </tooltip>
+                <input type="text" class="form-control" [(ngModel)]="_testUrl" (modelChanged)="testRegex()" />
+            </fieldset>
+            <fieldset>
+                <div>
+                    <label>Substitution Value</label>
+                    <tooltip>
+                        This is the substitution string to use when rewriting the response. The substitution value can include back-references to conditions and the rule pattern as well as server variables.
+                        <a href="https://docs.microsoft.com/en-us/iis/extensions/url-rewrite-module/creating-outbound-rules-for-url-rewrite-module" class="link"></a>
+                    </tooltip>
+                </div>
+                <input type="text" required [title]="_result" class="form-control left-with-button" [(ngModel)]="rule.rewrite_value" (modelChanged)="testRegex()" />
+                <button class="input" (click)="macros.toggle()" [class.background-active]="(macros && macros.opened) || false">Macros</button>
+                <selector class="stretch" #macros>
+                    <div class="table-scroll">
+                        <table>
+                            <tr *ngFor="let match of _matches; let i = index;" (dblclick)="addMatch(i)" (click)="select(i)" class="hover-editing" [class.background-selected]="_selected == i">
+                                <td class="back-ref border-color">{{ '{R:' + i + '}' }}</td>
+                                <td class="border-color">{{match}}</td>
+                            </tr>
+                            <tr *ngFor="let variable of _serverVariables; let i = index;" 
+                                (keyup.esc)="macros.toggle()" 
+                                (keyup.enter)="addVariable(i)" 
+                                (dblclick)="addVariable(i)"
+                                (keyup.space)="select(i + _matches.length)" 
+                                (click)="select(i + _matches.length)" 
+                                class="hover-editing" 
+                                [class.background-selected]="_selected == (i + _matches.length)">
+
+                                <td class="back-ref border-color">
+                                    <span tabindex="0">{{ '{' + variable + '}' }}</span>
+                                </td>
+                                <td class="border-color"></td>
+                            </tr>
+                        </table>
                     </div>
-                    <button class="right input" (click)="macros.toggle()" [class.background-active]="(macros && macros.opened) || false">Macros</button>
-                    <div class="fill">
-                        <input type="text" required [title]="_result" class="form-control" [(ngModel)]="rule.rewrite_value" (modelChanged)="testRegex()" />
-                    </div>
-                    <selector class="stretch" #macros>
-                        <div class="table-scroll">
-                            <table>
-                                <tr *ngFor="let match of _matches; let i = index;" (dblclick)="addMatch(i)" (click)="select(i)" class="hover-editing" [class.background-selected]="_selected == i">
-                                    <td class="back-ref border-color">{{ '{R:' + i + '}' }}</td>
-                                    <td class="border-color">{{match}}</td>
-                                </tr>
-                                <tr *ngFor="let variable of _serverVariables; let i = index;" (dblclick)="addVariable(i)" (click)="select(i + _matches.length)" class="hover-editing" [class.background-selected]="_selected == (i + _matches.length)">
-                                    <td class="back-ref border-color">{{ '{' + variable + '}' }}</td>
-                                    <td class="border-color"></td>
-                                </tr>
-                            </table>
-                        </div>
-                        <p class="pull-right">
-                            <button [attr.disabled]="_selected == -1 || null" (click)="addSelected()">Insert</button>
-                        </p>
-                    </selector>
-                </fieldset>
-            </div>
+                    <p class="pull-right">
+                        <button [attr.disabled]="_selected == -1 || null" (click)="addSelected()">Insert</button>
+                    </p>
+                </selector>
+            </fieldset>
         </div>
+    </div>
     `,
     styles: [`
+        .fill {
+            float: left;
+            width: 80%;
+        }
+
         table {
             width: 100%;
         }
@@ -82,6 +95,14 @@ import { OutboundRule, IIS_SERVER_VARIABLES } from '../url-rewrite';
             border-width: 1px;
             padding: 5px;
             border-top: none;
+        }
+
+        span:focus {
+            outline-style: dashed;
+            outline-color: #000;
+            outline-width: 2px;
+            outline-offset: -2px;
+            text-decoration: underline;
         }
 
         .back-ref {

--- a/src/app/webserver/url-rewrite/outbound-rules/outbound-rule-settings.ts
+++ b/src/app/webserver/url-rewrite/outbound-rules/outbound-rule-settings.ts
@@ -72,11 +72,6 @@ import { OutboundRule, IIS_SERVER_VARIABLES } from '../url-rewrite';
     </div>
     `,
     styles: [`
-        .fill {
-            float: left;
-            width: 80%;
-        }
-
         table {
             width: 100%;
         }

--- a/src/app/webserver/url-rewrite/outbound-rules/outbound-rules.component.ts
+++ b/src/app/webserver/url-rewrite/outbound-rules/outbound-rules.component.ts
@@ -24,7 +24,7 @@ import { OutboundSection, OutboundRule, PatternSyntax, OutboundTags, ActionType,
                 
                 <button class="create" [class.background-active]="newRule.opened" (click)="newRule.toggle()">Create Rule <i class="fa fa-caret-down"></i></button>
                 <selector #newRule class="container-fluid create" (hide)="initializeNewRule()">
-                    <outbound-rule-edit [rule]="_newRule" (save)="saveNew()" (cancel)="newRule.close()"></outbound-rule-edit>
+                    <outbound-rule-edit *ngIf="newRule.opened" [rule]="_newRule" (save)="saveNew()" (cancel)="newRule.close()"></outbound-rule-edit>
                 </selector>
             </div>
 

--- a/src/app/webserver/url-rewrite/providers/setting.component.ts
+++ b/src/app/webserver/url-rewrite/providers/setting.component.ts
@@ -71,18 +71,20 @@ export class SettingComponent implements OnChanges {
     selector: 'provider-setting-edit',
     template: `
         <div *ngIf="setting" class="grid-item row background-editing">
+            <fieldset class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
+                <fieldset>
+                    <label>Name</label>
+                    <input autofocus type="text" required class="form-control name" [(ngModel)]="setting.name" />
+                </fieldset>
+                <fieldset>
+                    <label>Value</label>
+                    <input type="text" required class="form-control name" [(ngModel)]="setting.value" />
+                </fieldset>
+            </fieldset>
             <div class="actions">
                 <button class="no-border ok" [disabled]="!isValid()" title="Ok" (click)="onOk()"></button>
                 <button class="no-border cancel" title="Cancel" (click)="onDiscard()"></button>
             </div>
-            <fieldset>
-                <label>Name</label>
-                <input type="text" required class="form-control name" [(ngModel)]="setting.name" />
-            </fieldset>
-            <fieldset>
-                <label>Value</label>
-                <input type="text" required class="form-control name" [(ngModel)]="setting.value" />
-            </fieldset>
         </div>
     `,
     styles: [`

--- a/src/app/webserver/url-rewrite/rewrite-maps/mapping.component.ts
+++ b/src/app/webserver/url-rewrite/rewrite-maps/mapping.component.ts
@@ -71,18 +71,20 @@ export class MappingComponent implements OnChanges {
     selector: 'rewrite-mapping-edit',
     template: `
         <div *ngIf="mapping" class="grid-item row background-editing">
+            <fieldset class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
+                <fieldset>
+                    <label>Name</label>
+                    <input autofocus type="text" required class="form-control name" [(ngModel)]="mapping.name" />
+                </fieldset>
+                <fieldset>
+                    <label>Value</label>
+                    <input type="text" required class="form-control name" [(ngModel)]="mapping.value" />
+                </fieldset>
+            </fieldset>
             <div class="actions">
                 <button class="no-border ok" [disabled]="!isValid()" title="Ok" (click)="onOk()"></button>
                 <button class="no-border cancel" title="Cancel" (click)="onDiscard()"></button>
             </div>
-            <fieldset>
-                <label>Name</label>
-                <input type="text" required class="form-control name" [(ngModel)]="mapping.name" />
-            </fieldset>
-            <fieldset>
-                <label>Value</label>
-                <input type="text" required class="form-control name" [(ngModel)]="mapping.value" />
-            </fieldset>
         </div>
     `,
     styles: [`

--- a/src/app/webserver/url-rewrite/url-rewrite.module.ts
+++ b/src/app/webserver/url-rewrite/url-rewrite.module.ts
@@ -15,6 +15,7 @@ import { Module as Selector } from '../../common/selector';
 import { Module as TextCheckbox } from '../../common/text-toggle.component';
 import { Module as StringList } from '../../common/string-list.component';
 import { Module as Tooltip } from '../../common/tooltip.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { UrlRewriteComponent } from './url-rewrite.component';
 
@@ -72,7 +73,8 @@ import { UrlRewriteService } from './service/url-rewrite.service';
         Selector,
         TextCheckbox,
         StringList,
-        Tooltip
+        Tooltip,
+        AutoFocus,
     ],
     declarations: [
         UrlRewriteComponent,

--- a/src/app/webserver/vdirs/vdir-list.component.ts
+++ b/src/app/webserver/vdirs/vdir-list.component.ts
@@ -53,14 +53,12 @@ import { WebApp } from '../webapps/webapp';
             <div *ngIf="_editing">                
                 <fieldset class="col-xs-8 col-sm-4 col-lg-3">
                     <label>Path</label>
-                    <input class="form-control" type="text" (ngModelChange)="model.path=$event" [ngModel]="model.path" throttle required />
+                    <input autofocus class="form-control" type="text" (ngModelChange)="model.path=$event" [ngModel]="model.path" throttle required />
                 </fieldset>
                 <fieldset class="col-xs-12 overflow">
                     <label class="block">Physical Path</label>
-                    <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="right select" (click)="fileSelector.toggle()"></button>
-                    <div class="fill">
-                        <input type="text" class="form-control block" [(ngModel)]="model.physical_path" throttle required />
-                    </div>
+                    <input type="text" class="form-control block left-with-button" [(ngModel)]="model.physical_path" throttle required />
+                    <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
                     <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="model.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
                 </fieldset>
                 <div class="col-xs-12">

--- a/src/app/webserver/vdirs/vdir-list.component.ts
+++ b/src/app/webserver/vdirs/vdir-list.component.ts
@@ -19,21 +19,6 @@ import { WebApp } from '../webapps/webapp';
     selector: 'vdir',
     template: `
         <div *ngIf="model" class="row grid-item" [class.background-editing]="_editing">
-            <div class="actions">
-                <button class="no-border no-editing" title="Edit" [class.inactive]="readonly" (click)="onEdit()">
-                    <i class="fa fa-pencil color-active"></i>
-                </button>
-                <button [disabled]="!isValid()" class="no-border editing" title="Ok" (click)="onSave()">
-                    <i class="fa fa-check color-active"></i>
-                </button>
-                <button class="no-border editing" title="Cancel" (click)="onCancel()">
-                    <i class="fa fa-times red"></i>
-                </button>
-                <button class="no-border" *ngIf="model.id" title="Delete" [class.inactive]="readonly" (click)="onDelete()">
-                    <i class="fa fa-trash-o red"></i>
-                </button>
-            </div>
-
             <div *ngIf="!_editing">
                 <div class="col-xs-8 col-sm-4 col-lg-3" [class.v-align]="!model.identity.username">
                     <div class="name">
@@ -50,51 +35,67 @@ import { WebApp } from '../webapps/webapp';
                 </div>
             </div>
 
-            <div *ngIf="_editing">                
-                <fieldset class="col-xs-8 col-sm-4 col-lg-3">
-                    <label>Path</label>
-                    <input autofocus class="form-control" type="text" (ngModelChange)="model.path=$event" [ngModel]="model.path" throttle required />
-                </fieldset>
-                <fieldset class="col-xs-12 overflow">
-                    <label class="block">Physical Path</label>
-                    <input type="text" class="form-control block left-with-button" [(ngModel)]="model.physical_path" throttle required />
-                    <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
-                    <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="model.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
-                </fieldset>
-                <div class="col-xs-12">
-                    <fieldset>
-                        <label>Custom Identity</label>
-                        <switch class="block" #customIdentity="switchVal" [model]="model.identity.username" (modelChange)="onUseCustomIdentity($event)">{{model.identity.username ? "On" : "Off"}}</switch>
+            <div *ngIf="_editing">
+                <fieldset class="col-lg-10 col-md-10 col-sm-8 col-xs-6 overflow-visible">
+                    <fieldset class="col-xs-8 col-sm-4 col-lg-3">
+                        <label>Path</label>
+                        <input autofocus class="form-control" type="text" (ngModelChange)="model.path=$event" [ngModel]="model.path" throttle required />
                     </fieldset>
-                    <div *ngIf="customIdentity.model">
-                        <div class="row">
-                            <fieldset class="col-sm-4 col-xs-12">
-                                <label>Username</label>
-                                <input class="form-control" type="text" [(ngModel)]="model.identity.username" throttle />
-                                <span>{{model.username}}</span>
-                            </fieldset>
-                        </div>
-                        <div class="row">
-                            <fieldset class="col-sm-4 col-xs-12">
-                                <label>Password</label>
-                                <input class="form-control" type="password" [(ngModel)]="_password" (modelChanged)="_confirm=''"/>
-                            </fieldset>
-                            <fieldset *ngIf="!!_password" class="col-sm-4 col-xs-12">
-                                <label>Confirm Password</label>
-                                <input class="form-control" type="password" [(ngModel)]="_confirm" (modelChanged)="onConfirmPassword" [validateEqual]="_password" />
-                            </fieldset>
-                        </div>
+                    <fieldset class="col-xs-12 overflow">
+                        <label class="block">Physical Path</label>
+                        <input type="text" class="form-control block left-with-button" [(ngModel)]="model.physical_path" throttle required />
+                        <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
+                        <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="model.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
+                    </fieldset>
+                    <div class="col-xs-12">
                         <fieldset>
-                            <label>Logon Method</label>
-                            <enum [(model)]="model.identity.logon_method">
-                                <field name="Clear Text" value="network_cleartext"></field>
-                                <field name="Network" value="network"></field>
-                                <field name="Interactive" value="interactive"></field>
-                                <field name="Batch" value="batch"></field>
-                            </enum>
+                            <label>Custom Identity</label>
+                            <switch class="block" #customIdentity="switchVal" [model]="model.identity.username" (modelChange)="onUseCustomIdentity($event)">{{model.identity.username ? "On" : "Off"}}</switch>
                         </fieldset>
+                        <div *ngIf="customIdentity.model">
+                            <div class="row">
+                                <fieldset class="col-sm-4 col-xs-12">
+                                    <label>Username</label>
+                                    <input class="form-control" type="text" [(ngModel)]="model.identity.username" throttle />
+                                    <span>{{model.username}}</span>
+                                </fieldset>
+                            </div>
+                            <div class="row">
+                                <fieldset class="col-sm-4 col-xs-12">
+                                    <label>Password</label>
+                                    <input class="form-control" type="password" [(ngModel)]="_password" (modelChanged)="_confirm=''"/>
+                                </fieldset>
+                                <fieldset *ngIf="!!_password" class="col-sm-4 col-xs-12">
+                                    <label>Confirm Password</label>
+                                    <input class="form-control" type="password" [(ngModel)]="_confirm" (modelChanged)="onConfirmPassword" [validateEqual]="_password" />
+                                </fieldset>
+                            </div>
+                            <fieldset>
+                                <label>Logon Method</label>
+                                <enum [(model)]="model.identity.logon_method">
+                                    <field name="Clear Text" value="network_cleartext"></field>
+                                    <field name="Network" value="network"></field>
+                                    <field name="Interactive" value="interactive"></field>
+                                    <field name="Batch" value="batch"></field>
+                                </enum>
+                            </fieldset>
+                        </div>
                     </div>
-                </div>
+                </fieldset>
+            </div>
+            <div class="actions">
+                <button class="no-border no-editing" title="Edit" [class.inactive]="readonly" (click)="onEdit()">
+                    <i class="fa fa-pencil color-active"></i>
+                </button>
+                <button [disabled]="!isValid()" class="no-border editing" title="Ok" (click)="onSave()">
+                    <i class="fa fa-check color-active"></i>
+                </button>
+                <button class="no-border editing" title="Cancel" (click)="onCancel()">
+                    <i class="fa fa-times red"></i>
+                </button>
+                <button class="no-border" *ngIf="model.id" title="Delete" [class.inactive]="readonly" (click)="onDelete()">
+                    <i class="fa fa-trash-o red"></i>
+                </button>
             </div>
         </div>
     `,

--- a/src/app/webserver/vdirs/vdirs.module.ts
+++ b/src/app/webserver/vdirs/vdirs.module.ts
@@ -8,6 +8,8 @@ import { Module as Validators } from '../../common/validators';
 import { Module as Switch } from '../../common/switch.component';
 import { Module as Sort } from '../../common/sort.pipe';
 import { Module as Enum } from '../../common/enum.component';
+import { Module as AutoFocus } from '../../common/focus';
+
 import { FilesModule } from '../../files/files.module';
 
 import { VdirsService } from './vdirs.service';
@@ -23,7 +25,8 @@ import { VdirListComponent, VdirListItem } from './vdir-list.component';
         Validators,
         Switch,
         Sort,
-        Enum
+        Enum,
+        AutoFocus,
     ],
     declarations: [
         VdirListComponent,

--- a/src/app/webserver/webapps/new-webapp.component.ts
+++ b/src/app/webserver/webapps/new-webapp.component.ts
@@ -19,14 +19,12 @@ import { ApplicationPool } from '../app-pools/app-pool';
             <tab [name]="'Settings'">
                 <fieldset>
                     <label>Path</label>
-                    <input type="text" class="form-control path" [(ngModel)]="model.path" required />
+                    <input autofocus type="text" class="form-control path" [(ngModel)]="model.path" required />
                 </fieldset>
                 <fieldset class="path">
                     <label>Physical Path</label>
-                    <button [class.background-active]="fileSelector.isOpen()" title="Select Folder" class="right select" (click)="fileSelector.toggle()"></button>
-                    <div class="fill">
-                        <input type="text" class="form-control" [(ngModel)]="model.physical_path" required />
-                    </div>
+                    <input type="text" class="form-control left-with-button" [(ngModel)]="model.physical_path" required />
+                    <button [class.background-active]="fileSelector.isOpen()" title="Select Folder" class="select" (click)="fileSelector.toggle()"></button>
                     <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="model.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
                 </fieldset>
             </tab>

--- a/src/app/webserver/webapps/webapp-general.component.ts
+++ b/src/app/webserver/webapps/webapp-general.component.ts
@@ -19,10 +19,8 @@ import { AppPoolListComponent } from '../app-pools/app-pool-list.component';
                 </fieldset>
                 <fieldset class="path">
                     <label>Physical Path</label>
-                    <button [class.background-active]="fileSelector.isOpen()" title="Select Folder" class="right select" (click)="fileSelector.toggle()"></button>
-                    <div class="fill">
-                        <input type="text" class="form-control" [(ngModel)]="model.physical_path" (modelChanged)="onModelChanged()" required />
-                    </div>
+                    <input type="text" class="form-control left-with-button" [(ngModel)]="model.physical_path" (modelChanged)="onModelChanged()" required />
+                    <button [class.background-active]="fileSelector.isOpen()" title="Select Folder" class="select" (click)="fileSelector.toggle()"></button>
                     <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="model.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
                 </fieldset>
 

--- a/src/app/webserver/webapps/webapp-list.component.ts
+++ b/src/app/webserver/webapps/webapp-list.component.ts
@@ -16,7 +16,7 @@ import {ApplicationPool} from '../app-pools/app-pool';
         <div *ngIf="website">
             <button [class.background-active]="newWebApp.opened" (click)="newWebApp.toggle()">Create Web Application <i class="fa fa-caret-down"></i></button>
             <selector #newWebApp class="container-fluid">
-                <new-webapp [website]="website" (created)="newWebApp.close()" (cancel)="newWebApp.close()"></new-webapp>
+                <new-webapp *ngIf="newWebApp.opened" [website]="website" (created)="newWebApp.close()" (cancel)="newWebApp.close()"></new-webapp>
             </selector>
         </div>
         <br/>

--- a/src/app/webserver/webapps/webapps.module.ts
+++ b/src/app/webserver/webapps/webapps.module.ts
@@ -11,6 +11,7 @@ import { Module as Loading } from '../../notification/loading.component';
 import { Module as Sort } from '../../common/sort.pipe';
 import { Module as Selector } from '../../common/selector';
 import { Module as Tabs } from '../../common/tabs.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { Module as WebSitesModule } from '../websites/module';
 import { Module as AppPoolsModule } from '../app-pools/module';
@@ -42,7 +43,8 @@ import { NewWebAppComponent } from './new-webapp.component';
         Loading,
         Sort,
         Selector,
-        Tabs
+        Tabs,
+        AutoFocus,
     ],
     declarations: [
         WebAppComponent,

--- a/src/app/webserver/websites/binding-list.component.ts
+++ b/src/app/webserver/websites/binding-list.component.ts
@@ -42,7 +42,7 @@ import { Binding } from './site';
                 </div>
             </div>
             
-            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible" *ngIf="edit">
+            <div class="col-lg-10 col-md-10 col-sm-10 overflow-visible" *ngIf="edit">
                 <fieldset class="col-xs-8 col-md-4" *ngIf="isHttp()">
                     <label>Host Name</label>
                     <input autofocus class="form-control" type="text" [(ngModel)]="model.hostname"/>

--- a/src/app/webserver/websites/binding-list.component.ts
+++ b/src/app/webserver/websites/binding-list.component.ts
@@ -14,21 +14,6 @@ import { Binding } from './site';
     selector: 'binding-item',
     template: `
         <div class="row grid-item" [class.background-editing]="edit">
-            <div class="actions">
-                <button title="Edit" [disabled]="!allowed('edit')" class='no-editing' (click)="onEdit()">
-                    <i class="fa fa-pencil color-active"></i>
-                </button>
-                <button title="Save" [disabled]="!isValid()" class="editing" (click)="onSave()">
-                    <i class="fa fa-check color-active"></i>
-                </button>
-                <button title="Cancel" class="editing" (click)="onCancel()">
-                    <i class="fa fa-times red"></i>
-                </button>
-                <button title="Delete" *ngIf="!model.isNew" [disabled]="!allowed('delete')" (click)="onDelete()">
-                    <i class="fa fa-trash-o red"></i>
-                </button>
-            </div>
-
             <div class='valign' *ngIf="!edit">
                 <div class="col-xs-8 col-md-1">
                     <label class="visible-xs visible-sm">Protocol</label>
@@ -56,12 +41,11 @@ import { Binding } from './site';
                     </div>
                 </div>
             </div>
-
-
-            <div class="valign" *ngIf="edit">
+            
+            <div class="col-xs-8 col-sm-4 col-lg-5 overflow-visible" *ngIf="edit">
                 <fieldset class="col-xs-8 col-md-4" *ngIf="isHttp()">
                     <label>Host Name</label>
-                    <input class="form-control" type="text" [(ngModel)]="model.hostname"/>
+                    <input autofocus class="form-control" type="text" [(ngModel)]="model.hostname"/>
                 </fieldset>
                 <fieldset class="col-xs-12 col-sm-10 col-md-4" *ngIf="isHttp()">
                     <label>IP Address</label>
@@ -109,7 +93,26 @@ import { Binding } from './site';
                     </fieldset>
                 </div>
             </div>
+
+            <div>
+                <div class="actions">
+                    <button title="Edit" [disabled]="!allowed('edit')" class='no-editing' (click)="onEdit()">
+                        <i class="fa fa-pencil color-active"></i>
+                    </button>
+                    <button title="Save" [disabled]="!isValid()" class="editing" (click)="onSave()">
+                        <i class="fa fa-check color-active"></i>
+                    </button>
+                    <button title="Cancel" class="editing" (click)="onCancel()">
+                        <i class="fa fa-times red"></i>
+                    </button>
+                    <button title="Delete" *ngIf="!model.isNew" [disabled]="!allowed('delete')" (click)="onDelete()">
+                        <i class="fa fa-trash-o red"></i>
+                    </button>
+                </div>
+            </div>
         </div>
+
+        
     `,
     styles: [`
         .grid-item > div {

--- a/src/app/webserver/websites/binding-list.component.ts
+++ b/src/app/webserver/websites/binding-list.component.ts
@@ -56,7 +56,7 @@ import { Binding } from './site';
                     <input class="form-control" type="number" max="65535" min="1" [(ngModel)]="model.port" required />
                 </fieldset>
 
-                <div class="col-xs-12 overflow-visible" *ngIf="isHttp()">   
+                <div class="col-xs-12 overflow-visible" *ngIf="isHttp()">
                     <fieldset class="inline-block">
                         <label>HTTPS</label>
                         <switch class="block" (modelChange)="model.is_https=$event" [model]="model.is_https" (modelChanged)=onHttps()>{{model.is_https ? "On" : "Off"}}</switch>

--- a/src/app/webserver/websites/binding-list.component.ts
+++ b/src/app/webserver/websites/binding-list.component.ts
@@ -73,7 +73,7 @@ import { Binding } from './site';
                         <selector #certSelect [hidden]="!certSelect || !certSelect.isOpen()" (hide)="onCertSelected()" class="container-fluid">
                             <certificates-list #list (itemSelected)="onCertSelected($event)"></certificates-list>
                         </selector>
-                    </div> 
+                    </div>
                     <fieldset class="certificate" *ngIf="model.is_https && model.certificate">
                         <certificate-details [model]="model.certificate"></certificate-details>
                     </fieldset>

--- a/src/app/webserver/websites/new-website.component.ts
+++ b/src/app/webserver/websites/new-website.component.ts
@@ -18,14 +18,12 @@ import { ApplicationPool } from '../app-pools/app-pool';
             <tab [name]="'Settings'">
                 <fieldset>
                     <label>Name</label>
-                    <input type="text" class="form-control name" [ngModel]="site.name" (ngModelChange)="onNameChange($event)" required />
+                    <input autofocus type="text" class="form-control name" [ngModel]="site.name" (ngModelChange)="onNameChange($event)" required />
                 </fieldset>
                 <fieldset class="path">
                     <label>Physical Path</label>
-                    <button [class.background-active]="fileSelector.isOpen()" title="Select Folder" class="right select" (click)="fileSelector.toggle()"></button>
-                    <div class="fill">
-                        <input type="text" class="form-control" [(ngModel)]="site.physical_path" required />
-                    </div>
+                    <input type="text" class="form-control left-with-button" [(ngModel)]="site.physical_path" required />
+                    <button [class.background-active]="fileSelector.isOpen()" title="Select Folder" class="left select" (click)="fileSelector.toggle()"></button>
                     <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="site.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
                 </fieldset>
             </tab>

--- a/src/app/webserver/websites/website-general.component.ts
+++ b/src/app/webserver/websites/website-general.component.ts
@@ -24,10 +24,8 @@ import { AppPoolsService } from '../app-pools/app-pools.service';
                 </fieldset>
                 <fieldset class="path">
                     <label>Physical Path</label>
-                    <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="right select" (click)="fileSelector.toggle()"></button>
-                    <div class="fill">
-                        <input type="text" class="form-control" [(ngModel)]="site.physical_path" (modelChanged)="onModelChanged()" throttle required />
-                    </div>
+                    <input type="text" class="form-control left-with-button" [(ngModel)]="site.physical_path" (modelChanged)="onModelChanged()" throttle required />
+                    <button title="Select Folder" [class.background-active]="fileSelector.isOpen()" class="select" (click)="fileSelector.toggle()"></button>
                     <server-file-selector #fileSelector [types]="['directory']" [defaultPath]="site.physical_path" (selected)="onSelectPath($event)"></server-file-selector>
                 </fieldset>
                 <fieldset>

--- a/src/app/webserver/websites/website-list.component.ts
+++ b/src/app/webserver/websites/website-list.component.ts
@@ -21,7 +21,7 @@ import { ApplicationPool } from '../app-pools/app-pool';
         <div *ngIf="!appPool && service.installStatus != 'stopped'">
             <button [class.background-active]="newWebSite.opened" (click)="newWebSite.toggle()">Create Web Site <i class="fa fa-caret-down"></i></button>
             <selector #newWebSite class="container-fluid">
-                <new-website (created)="newWebSite.close()" (cancel)="newWebSite.close()"></new-website>
+                <new-website *ngIf="newWebSite.opened" (created)="newWebSite.close()" (cancel)="newWebSite.close()"></new-website>
             </selector>
         </div>
         <br/>

--- a/src/app/webserver/websites/websites.module.ts
+++ b/src/app/webserver/websites/websites.module.ts
@@ -15,6 +15,7 @@ import { Module as Selector } from '../../common/selector';
 import { Module as Tabs } from '../../common/tabs.component';
 import { Module as VirtualList } from '../../common/virtual-list.component';
 import { Module as Enum } from '../../common/enum.component';
+import { Module as AutoFocus } from '../../common/focus';
 
 import { Module } from './module';
 import { Module as AppPoolModule } from '../app-pools/module';
@@ -52,7 +53,8 @@ import { LimitsComponent } from './limits.component';
         Tabs,
         VirtualList,
         Enum,
-        RouterModule
+        RouterModule,
+        AutoFocus,
     ],
     declarations: [
         WebSiteComponent,

--- a/src/build/targets/Node.targets
+++ b/src/build/targets/Node.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
-  <ItemGroup>  
+  <ItemGroup>
     <NodeModulesDir Include="node_modules" /> 
-  </ItemGroup>  
+  </ItemGroup>
   <Target Name="NpmInstall" BeforeTargets="PreComputeCompileTypeScript" Condition="!Exists(@(NodeModulesDir)) Or '$(Configuration)' == 'Release'">
     <Exec Command="npm install" />
   </Target>

--- a/src/themes/main.css
+++ b/src/themes/main.css
@@ -119,7 +119,7 @@ span.form-control {
 }
 
 .form-control[hidden] {
-    display: none;
+    display: none !important;
 }
 
 input[type='number'] {
@@ -131,6 +131,11 @@ input:required:invalid:not(.unfocused),
 input:not(:required).ng-invalid {
     border-left-width: 6px;
     border-left-style: solid;
+}
+
+.left-with-button {
+    float: left;
+    width: 80%;
 }
 
 .bttn {


### PR DESCRIPTION
Added autofocus and fix the tab order with switching from (actions, UI controls) to (UI controls, actions).

NOTE:

1. In order to make the autofocus directive works, the element should be re-generated according to the value *ngIf directive. So, I had to add some *ngIf directives when required.

2. We still need to show the actions buttons on top of the form even though the actions buttons are moved bottom. In order to do that, I made one table (1 * 2) and make the first column uses 8/12 and uses the remained (4/12) are used for the action buttons.

3. Added keyup.[space|esc|enter] event handler to toggle/close/select focused element. 

4. .left-with-button is added to layout the text input box and then the button on the right side of the text input box.

5. In modules feature page, I added a wrapper span for switch button to make it autofocused. This is a work-around way and I will revisit to check if there is better solution.