### PR TITLE
Added sme-focus-zone to vtabs disabling autofocus in WAC mode

### DIFF
--- a/src/app/common/vtabs.component.ts
+++ b/src/app/common/vtabs.component.ts
@@ -7,12 +7,13 @@ import { Subscription } from 'rxjs/Subscription'
 
 import { DynamicComponent } from './dynamic.component';
 import { SectionHelper } from './section.helper';
+import { environment } from 'environments/environment';
 
 @Component({
     selector: 'vtabs',
     template: `
         <div class="vtabs">
-            <ul class="items">
+            <ul class="items sme-focus-zone">
                 <li
                     tabindex="0"
                     #item
@@ -26,7 +27,7 @@ import { SectionHelper } from './section.helper';
                     <i [class]="tab.ico"></i><span class="border-active">{{tab.name}}</span>
                 </li>
             </ul>
-            <div class="content">
+            <div class="content sme-focus-zone">
                 <ng-content></ng-content>
             </div>
         </div>
@@ -173,7 +174,7 @@ export class VTabsComponent implements OnDestroy {
     selector: 'vtabs > item',
     template: `
         <div *ngIf="!(!active)">
-            <span id="vtabs-title" tabindex="0"></span>
+            <span id="vtabs-title" [tabindex]="isWAC() ? -1 : 0"></span>
             <h1 class="border-active">
                 <span>{{name}}</span>
             </h1>
@@ -216,6 +217,9 @@ export class Item implements OnInit, OnDestroy {
         this._tabs.addTab(this);
     }
 
+    private isWAC() {
+        return environment.WAC;
+    }
     activate() {
         if (this.dynamicChildren) {
             this.dynamicChildren.forEach(child => child.activate());

--- a/src/app/common/vtabs.component.ts
+++ b/src/app/common/vtabs.component.ts
@@ -220,6 +220,7 @@ export class Item implements OnInit, OnDestroy {
     private isWAC() {
         return environment.WAC;
     }
+    
     activate() {
         if (this.dynamicChildren) {
             this.dynamicChildren.forEach(child => child.activate());

--- a/src/app/webserver/app-pools/app-pool-header.component.ts
+++ b/src/app/webserver/app-pools/app-pool-header.component.ts
@@ -23,7 +23,7 @@ import { AppPoolsService } from './app-pools.service';
                     </selector>
                 </div>
             </div>
-            <div class="feature-title">
+            <div class="feature-title sme-focus-zone">
                 <h1 [ngClass]="pool.status">{{pool.name}}</h1>
                 <span class="status" *ngIf="pool.status == 'stopped'">{{pool.status}}</span>
             </div>

--- a/src/app/webserver/app-pools/app-pool.component.ts
+++ b/src/app/webserver/app-pools/app-pool.component.ts
@@ -16,7 +16,7 @@ import {AppPoolsService} from './app-pools.service';
         <app-pool-header *ngIf="pool" [pool]="pool" class="crumb-content" [class.sidebar-nav-content]="_options.active"></app-pool-header>
 
         <div *ngIf="pool" class="sidebar crumb" [class.nav]="_options.active">
-            <ul class="crumbs">
+            <ul class="crumbs sme-focus-zone">
                 <li><a [routerLink]="['/webserver']">Web Server</a></li>
                 <li><a [routerLink]="['/webserver/application-pools']">Application Pools</a></li>
             </ul>

--- a/src/app/webserver/webapps/webapp-header.component.ts
+++ b/src/app/webserver/webapps/webapp-header.component.ts
@@ -21,7 +21,7 @@ import { WebSitesService } from '../websites/websites.service';
                     </selector>
                 </div>
             </div>
-            <div class="feature-title">
+            <div class="feature-title sme-focus-zone">
                 <h1 [title]="model.website.name + model.path">{{model.path}}</h1>
             </div>
         </div>

--- a/src/app/webserver/webapps/webapp.component.ts
+++ b/src/app/webserver/webapps/webapp.component.ts
@@ -17,7 +17,7 @@ import {WebAppsService} from './webapps.service';
         <webapp-header *ngIf="app" [model]="app" class="crumb-content" [class.sidebar-nav-content]="_options.active"></webapp-header>
 
         <div *ngIf="app" class="sidebar crumb" [class.nav]="_options.active">
-            <ul class="crumbs">
+            <ul class="crumbs sme-focus-zone">
                 <li><a [routerLink]="['/webserver']">Web Server</a></li>
                 <li><a [routerLink]="['/webserver/web-sites/']">Web Sites</a></li>
                 <li><a [routerLink]="['/webserver/websites/', app.website.id]">{{app.website.name}}</a></li>

--- a/src/app/webserver/webserver-header.component.ts
+++ b/src/app/webserver/webserver-header.component.ts
@@ -24,7 +24,7 @@ import { WebServer } from './webserver';
                     </selector>
                 </div>
             </div>
-            <div class="feature-title">
+            <div class="feature-title sme-focus-zone">
                 <h1 [ngClass]="model.status">Web Server</h1>
                 <span class="status" *ngIf="model.status.startsWith('stop')">{{model.status}}</span>
             </div>

--- a/src/app/webserver/websites/website-header.component.ts
+++ b/src/app/webserver/websites/website-header.component.ts
@@ -25,7 +25,7 @@ import { WebSite } from './site';
                 </div>
             </div>
             
-            <div class="feature-title">
+            <div class="feature-title sme-focus-zone">
                 <h1 [ngClass]="site.status">{{site.name}}</h1>
                 <span class="status" *ngIf="site.status == 'stopped'">{{site.status}}</span>
             </div>

--- a/src/app/webserver/websites/website.component.ts
+++ b/src/app/webserver/websites/website.component.ts
@@ -15,7 +15,7 @@ import { OptionsService } from '../../main/options.service';
         <loading *ngIf="!(site || notFound)"></loading>
         <website-header *ngIf="site" [site]="site" class="crumb-content" [class.sidebar-nav-content]="_options.active"></website-header>
         <div *ngIf="site" class="sidebar crumb" [class.nav]="_options.active">
-            <ul class="crumbs">
+            <ul class="crumbs sme-focus-zone">
                 <li><a [routerLink]="['/webserver']">Web Server</a></li>
                 <li><a [routerLink]="['/webserver/web-sites']">Web Sites</a></li>
             </ul>


### PR DESCRIPTION
WAC has a global keyboard hander and we have to enable it with adding sme-focus-zone.
I added this to both tab lists and each active content page. 

BTW, the keyboard handler does not use tab and users should switch between focus-zone with tab key manually. 
So, I had to disable the autofocus feature of auto-selection for the invisible vtabs-title element for the selected tab only in WAC mode.