### PR TITLE
Removed hard-coded nuget package version

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -26,16 +26,12 @@ function ShouldNPMInstall {
 
 $purge = $args | Where-Object { $_ -like "--purge" }
 $pack = $args | Where-Object { $_ -like "--pack" }
-$pack_build = $args | Where-Object { $_.startsWith("--pack.build=") }
-if ($pack_build) {
-    # Example: --pack.build=0.1.$(Build.BuildNumber)/$(Build.SourceVersion)
-    Write-Host ($pack_build)
-    $tokens = $pack_build.split("=")[1].trim().split("/")  
-    $pack_build = $pack_build = $tokens[0]
-} else {
-    $pack_build = "0.1.0" # default value
+$version = $args | Where-Object { $_.startsWith("--version=") }
+if ($version) {
+    # Example: --version=0.1.$(Build.BuildNumber)
+    Write-Host ($version)
+    $version = $version.split("=")[1]
 }
-Write-Host ("pack_build: " + $pack_build)
 
 if (!(Get-Command "npm" -ErrorAction SilentlyContinue)) {
     throw "npm is required in PATH"
@@ -49,7 +45,7 @@ if ($pack -and !(Get-Command "nuget" -ErrorAction SilentlyContinue)) {
     throw """--pack"" operation requires nugetin PATH"
 }
 
-$buildArgs = $args | Where-Object { $_ -notlike "--purge" -and $_ -notlike "--pack" -and -not ($_.startsWith("--pack.build="))}
+$buildArgs = $args | Where-Object { $_ -notlike "--purge" -and $_ -notlike "--pack" -and -not ($_.startsWith("--version="))}
 $buildTools = @("@angular/cli@1.7.4","gulp-cli@2.0.1")
 
 Push-Location src
@@ -75,7 +71,7 @@ try {
 
     Write-Host ("OutputDirectory: " + (Resolve-Path "..\dist").Path)
     if ($pack) {
-        nuget pack . -Version $pack_build -OutputDirectory (Resolve-Path "..\dist").Path
+        nuget pack . -Version $version -OutputDirectory (Resolve-Path "..\dist").Path
     }
 } finally {
     Pop-Location

--- a/src/wac-iis.nuspec
+++ b/src/wac-iis.nuspec
@@ -5,7 +5,7 @@
       <packageType name="WindowsAdminCenterExtension" />
     </packageTypes>
     <id>microsoft.iis-wac-extension</id>
-    <version>0.1.0</version>
+    <version>$version$</version>
     <title>Microsoft IIS Extension for Windows Administration Center</title>
     <authors>Microsoft IIS Team</authors>
     <owners>iiscore@microsoft.com</owners>


### PR DESCRIPTION
Removed the hard-coded version added a new --version parameter for the build.ps1.

Ex:
    --version=0.1.$(Build.BuildNumber)

This will be converted like 0.1.555 and the nuget package will be published @https://www.myget.org/feed/iis-wac/package/nuget/microsoft.iis-wac-extension with the specified version.

In manual build, we can also set the parameter like this as well.

    --version=1.0.0-RC