### PR TITLE
Fix: #228 Added missing ToPromise and closing popup window

### DIFF
--- a/src/app/connect/connect.service.ts
+++ b/src/app/connect/connect.service.ts
@@ -65,9 +65,12 @@ export class ConnectService {
             this._pingPopup.open(conn.url + "/ping");
 
             // Raw request to url causes certificate acceptance prompt on IE.
-            this._client.raw(conn, "/api").toPromise().then(_ => { }).catch(e => {
-                // Ignore errors
-            });
+            this._client.raw(conn, "/api")
+            .subscribe(
+                _ => {}, 
+                e => {}, // Ignore errors
+                () => { this._pingPopup.close(); } 
+            );
         }
 
         return this._client.get(conn, "/api")

--- a/src/app/settings/server-list-item.ts
+++ b/src/app/settings/server-list-item.ts
@@ -177,7 +177,7 @@ export class ServerListItem implements OnInit, OnDestroy {
             e.preventDefault();
         }
 
-        this._svc.connect(this.model);
+        this._svc.connect(this.model).toPromise();
     }
 
     private onDelete() {


### PR DESCRIPTION
Fixing https://github.com/Microsoft/IIS.WebManager/issues/228

This issue happened because we missed calling subscribe() in the onConnect() function after the migration of promise object to observable object for http requests.

