### PR TITLE
Fixing incorrectly added _pingPopup.clos()

### DIFF
--- a/src/app/connect/connect.service.ts
+++ b/src/app/connect/connect.service.ts
@@ -66,11 +66,10 @@ export class ConnectService {
 
             // Raw request to url causes certificate acceptance prompt on IE.
             this._client.raw(conn, "/api")
-            .subscribe(
-                _ => {}, 
-                e => {}, // Ignore errors
-                () => { this._pingPopup.close(); } 
-            );
+                .subscribe(
+                    _ => {},
+                    e => {} // Ignore errors
+                );
         }
 
         return this._client.get(conn, "/api")


### PR DESCRIPTION
I misunderstood the logic. We don't need to call _pingPopup.close() because it is supposed to be done by other function such as this.reset().