### PR TITLE
Jhkim/fix case sensitive issue

### DIFF
--- a/src/app/resources/iis_scripts/admin_api_util.ps1
+++ b/src/app/resources/iis_scripts/admin_api_util.ps1
@@ -123,7 +123,7 @@ function EnsureGroup($group) {
 }
 
 function EnsureMember($group, $userOrGroup) {
-    $modify = !(Get-LocalGroupMember -Group $group -Member $userOrGroup -ErrorAction SilentlyContinue)
+    $modify = !(Get-LocalGroupMember -Group $group | Where-Object { $_.Name -eq $user })
     if ($modify) {
         Add-LocalGroupMember -Group $group -Member $userOrGroup | Out-Null
         LogVerbose "Member $userOrGroup added"

--- a/src/app/resources/iis_scripts/admin_api_util.ps1
+++ b/src/app/resources/iis_scripts/admin_api_util.ps1
@@ -123,7 +123,7 @@ function EnsureGroup($group) {
 }
 
 function EnsureMember($group, $userOrGroup) {
-    $modify = !(Get-LocalGroupMember -Group $group | Where-Object { $_.Name -eq $user })
+    $modify = !(Get-LocalGroupMember -Group $group -ErrorAction SilentlyContinue | Where-Object { $_.Name -eq $user })
     if ($modify) {
         Add-LocalGroupMember -Group $group -Member $userOrGroup | Out-Null
         LogVerbose "Member $userOrGroup added"
@@ -251,7 +251,7 @@ if ($saveConfig) {
         throw "Cannot edit config file in dev mode, please add $user to ""$iisAdminOwners"" group manually"
     }
     ## Check the current user is a member of the Administrators local user group
-    if (!(Get-LocalGroupMember -SID $administratorsSID -Member $user -ErrorAction SilentlyContinue)) {
+    if (!(Get-LocalGroupMember -SID $administratorsSID -ErrorAction SilentlyContinue | Where-Object { $_.Name -eq $user } )) {
         throw "User $user lacks administrator privilege which is needed to initiate IIS Administration API"
     }
     $apiHome = [System.IO.Path]::Combine($workingDirectory, "..")

--- a/src/app/resources/iis_scripts/admin_api_util.ps1
+++ b/src/app/resources/iis_scripts/admin_api_util.ps1
@@ -123,6 +123,7 @@ function EnsureGroup($group) {
 }
 
 function EnsureMember($group, $userOrGroup) {
+    ## NOTE: Get-LocalGroupMember works case-insensitevly. So, as a workaround, Where-Object is used here
     $modify = !(Get-LocalGroupMember -Group $group -ErrorAction SilentlyContinue | Where-Object { $_.Name -eq $userOrGroup })
     if ($modify) {
         Add-LocalGroupMember -Group $group -Member $userOrGroup | Out-Null
@@ -251,6 +252,7 @@ if ($saveConfig) {
         throw "Cannot edit config file in dev mode, please add $user to ""$iisAdminOwners"" group manually"
     }
     ## Check the current user is a member of the Administrators local user group
+    ## NOTE: Get-LocalGroupMember works case-insensitevly. So, as a workaround, Where-Object is used here
     if (!(Get-LocalGroupMember -SID $administratorsSID -ErrorAction SilentlyContinue | Where-Object { $_.Name -eq $user } )) {
         throw "User $user lacks administrator privilege which is needed to initiate IIS Administration API"
     }

--- a/src/app/resources/iis_scripts/admin_api_util.ps1
+++ b/src/app/resources/iis_scripts/admin_api_util.ps1
@@ -123,7 +123,7 @@ function EnsureGroup($group) {
 }
 
 function EnsureMember($group, $userOrGroup) {
-    $modify = !(Get-LocalGroupMember -Group $group -ErrorAction SilentlyContinue | Where-Object { $_.Name -eq $user })
+    $modify = !(Get-LocalGroupMember -Group $group -ErrorAction SilentlyContinue | Where-Object { $_.Name -eq $userOrGroup })
     if ($modify) {
         Add-LocalGroupMember -Group $group -Member $userOrGroup | Out-Null
         LogVerbose "Member $userOrGroup added"


### PR DESCRIPTION
Get-LocalGroupMember works case-sensitively and fails in localized languages such as Germany.
As a work-around, we decided to use the where-object which works case-insensitively.