### PR TITLE
Fixed case-sensitive paramer value from ALL to all

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./build.ps1
-      arguments: '--env=wac --output-hashing ALL'
+      arguments: '--env=wac --output-hashing all'
 
   - task: NuGetCommand@2
     displayName: 'NuGet pack (development)'

--- a/build.ps1
+++ b/build.ps1
@@ -57,7 +57,7 @@ if ($pack) {
     if (
         ($outputHashingIndex -eq -1) -Or
         ($outputHashingIndex+1 -ge $args.Count) -Or
-        ($args[$outputHashingIndex+1].Equals("all"))
+        -not ($args[$outputHashingIndex+1].Equals("all"))
     ) {
         throw "Please include ""$outputHashingTag all"" option when packing"
     }

--- a/build.ps1
+++ b/build.ps1
@@ -57,7 +57,7 @@ if ($pack) {
     if (
         ($outputHashingIndex -eq -1) -Or
         ($outputHashingIndex+1 -ge $args.Count) -Or
-        ($args[$outputHashingIndex+1] -ne "all")
+        ($args[$outputHashingIndex+1].Equals("all"))
     ) {
         throw "Please include ""$outputHashingTag all"" option when packing"
     }

--- a/build.ps1
+++ b/build.ps1
@@ -57,7 +57,7 @@ if ($pack) {
     if (
         ($outputHashingIndex -eq -1) -Or
         ($outputHashingIndex+1 -ge $args.Count) -Or
-        ($args[$outputHashingIndex+1].ToLower() -ne "all")
+        ($args[$outputHashingIndex+1] -ne "all")
     ) {
         throw "Please include ""$outputHashingTag all"" option when packing"
     }

--- a/build.ps1
+++ b/build.ps1
@@ -54,6 +54,7 @@ if ($pack) {
             break
         }
     }
+
     if (
         ($outputHashingIndex -eq -1) -Or
         ($outputHashingIndex+1 -ge $args.Count) -Or

--- a/build.ps1
+++ b/build.ps1
@@ -59,7 +59,7 @@ if ($pack) {
         ($outputHashingIndex+1 -ge $args.Count) -Or
         ($args[$outputHashingIndex+1].ToLower() -ne "all")
     ) {
-        throw "Please include ""$outputHashingTag ALL"" option when packing"
+        throw "Please include ""$outputHashingTag all"" option when packing"
     }
 }
 


### PR DESCRIPTION
The value of --output-hashing is case sensitive. We have to use "all" not "ALL".
