### PR TITLE
cleanup sme_focus_zone

### DIFF
--- a/src/app/common/vtabs.component.ts
+++ b/src/app/common/vtabs.component.ts
@@ -17,10 +17,10 @@ import { IsWAC } from 'environments/environment';
     // That is because users are allowed to use only tab key, not arrow keys, unlike the WAC mode.
     template: `
         <div class="vtabs">
-            <ul class="items sme-focus-zone">
+            <ul class="items">
                 <ng-container *ngFor="let category of getCategories()">
                     <div class="sme-focus-zone">
-                    <li [attr.tabindex]=" isWAC() ? '0' : null " *ngIf="!!category" class="separator">
+                        <li [attr.tabindex]=" isWAC() ? '0' : null " *ngIf="!!category" class="separator">
                             <div class="horizontal-strike">
                                 <span>{{category}}</span>
                             </div>


### PR DESCRIPTION
This is a simple cleanup work.
I forgot to remove the sme_focus_zone class in the parent by mistake. 