### PR TITLE
use either exception or error while unwraping AjaxError object

### DIFF
--- a/src/app/runtime/runtime.wac.ts
+++ b/src/app/runtime/runtime.wac.ts
@@ -123,10 +123,11 @@ export class WACRuntime implements Runtime {
     private GetApiKey(): Observable<ApiKey> {
         return this.PrepareIISHost({ command: 'ensure' }).pipe(
             catchError((e, _) => {
-                if (e.status === 400 && e.response && e.response.exception) {
+                let errString = e as string;
+                if (errString) {
                     let errContent: any;
                     try {
-                        errContent = JSON.parse(e.response.exception);
+                        errContent = JSON.parse(errString);
                     } catch (e) {
                         this._logger.log(LogLevel.INFO,
                             `Unable to parse error message ${e}, the error must be unexpected`);

--- a/src/app/runtime/wac/services/powershell-service.ts
+++ b/src/app/runtime/wac/services/powershell-service.ts
@@ -120,8 +120,13 @@ export class PowershellService {
       catchError((e, _) => {
         let rethrow = e;
         // WAC wrap the powershell error message around this AjaxError object. We would unwrap it for easier readability
-        if (e.name == "AjaxError" && e.status == 400 && e.response.error) {
-          rethrow = e.response.error;
+        if (e.name == "AjaxError" && e.status == 400) {
+          if (e.response.error && !e.response.exception) {
+            rethrow = e.response.error;
+          } 
+          if (!e.response.error && e.response.exception) {
+            rethrow = e.response.exception;
+          }
         }
         throw rethrow;
       }),

--- a/src/app/runtime/wac/services/powershell-service.ts
+++ b/src/app/runtime/wac/services/powershell-service.ts
@@ -119,7 +119,7 @@ export class PowershellService {
       }),
       catchError((e, _) => {
         let rethrow = e;
-        // WAC wrap the powershell error message around this AjaxError object. We would unwrap it for easier readability
+        // WAC wrap the powershell error (or exception) message around this AjaxError object. We would unwrap it for easier readability
         if (e.name == "AjaxError" && e.status == 400) {
           if (e.response.error && !e.response.exception) {
             rethrow = e.response.error;


### PR DESCRIPTION
When authentication error (401) happens, exception is used instead of error.
We decided to handle both of them.

The screenshot after the update which I got while testing unauthorized users. (we can test this with updating appsettings.json and removing the current user):

![image](https://user-images.githubusercontent.com/20650163/59296622-492a9f80-8c3b-11e9-96fc-09ea1272cada.png)
