### PR TITLE
UI: Fixed switch label alignment issue and removed SME-FOCUS-ZONE from TAB UI

### DIFF
--- a/src/app/common/switch.component.ts
+++ b/src/app/common/switch.component.ts
@@ -122,8 +122,9 @@ import { FormsModule } from '@angular/forms';
 
         .switch-line {
             display:inline-block;
-            vertical-align:bottom;
-            line-height:34px;
+            position: relative;
+            left: 105px;
+            top: -30px;
         }
     `],
     template: `
@@ -135,9 +136,9 @@ import { FormsModule } from '@angular/forms';
                 <input #checkbox class="switch-input" type="checkbox"  [ngModel]="toBool()" (ngModelChange)="updateData($event)"/>
                 <span class="switch-content border-color background-normal" ><div class="switch-fill background-active"></div></span>
                 <span class="switch-handle border-active background-normal"></span>
+                <span class="switch-line"><ng-content></ng-content></span>
             </label>
         </div>
-        <div class="switch-line"><ng-content></ng-content></div>
     `,
     exportAs: 'switchVal'
 })

--- a/src/app/common/switch.component.ts
+++ b/src/app/common/switch.component.ts
@@ -124,7 +124,7 @@ import { FormsModule } from '@angular/forms';
             display:inline-block;
             position: relative;
             left: 100px;
-            top: -30px;
+            top: -28px;
             font-weight: normal;
         }
     `],

--- a/src/app/common/switch.component.ts
+++ b/src/app/common/switch.component.ts
@@ -125,6 +125,7 @@ import { FormsModule } from '@angular/forms';
             position: relative;
             left: 105px;
             top: -30px;
+            font-weight: normal;
         }
     `],
     template: `

--- a/src/app/common/switch.component.ts
+++ b/src/app/common/switch.component.ts
@@ -123,7 +123,7 @@ import { FormsModule } from '@angular/forms';
         .switch-line {
             display:inline-block;
             position: relative;
-            left: 105px;
+            left: 100px;
             top: -30px;
             font-weight: normal;
         }

--- a/src/app/common/tabs.component.ts
+++ b/src/app/common/tabs.component.ts
@@ -6,7 +6,6 @@ import { Subscription } from 'rxjs'
 import { DynamicComponent } from './dynamic.component';
 import { ComponentUtil } from '../utils/component';
 import { SectionHelper } from './section.helper';
-import { IsWAC } from 'environments/environment';
 
 @Component({
     selector: 'tabs',
@@ -169,39 +168,34 @@ import { IsWAC } from 'environments/environment';
     // In the site mode, we can't select the feature when input-focus is change.
     // That is because users are allowed to use only tab key, not arrow keys, unlike the WAC mode.    
     template: `
-        <div class='sme-focus-zone'>
-            <div class="tab-nav">
-                <div class="tabs-container">
-                    <div class='tabs border-active'>
-                        <ul>
-                            <li 
-                                #item 
-                                tabindex="0" 
-                                *ngFor="let tab of tabs; let i = index"
-                                class="border-active border-bottom-normal"
-                                [ngClass]="{active: tab.active}"
-                                (keyup.space)="selectTab(i)"
-                                (keyup.enter)="selectTab(i)" 
-                                (focus)=" isWAC() ? selectTab(i) : '' "
-                                (click)="selectTab(i)">
-                                <span>{{tab.name}}</span>
-                            </li>
-                            <li *ngIf="_selectedIndex != -1" class="sticky background-normal border-active border-bottom-normal" [ngClass]="{active: !!'true', hidden: tabs[_selectedIndex].visible}" (click)="selectTab(_selectedIndex)">
-                                <span class="border-active">{{tabs[_selectedIndex].name}}</span>
-                            </li>
-                        </ul>
-                        <div class="hider background-normal"></div>
-                    </div>
-                </div>
-                <div class='menu-btn color-active background-normal' #menuBtn (click)="showMenu(true)"><span class="border-active hover-active color-normal" [class.background-active]="_menuOn"><i class="fa fa-ellipsis-h"></i></span></div>
-                <div class='menu border-active background-normal' [hidden]="!_menuOn">
+        <div class="tab-nav">
+            <div class="tabs-container">
+                <div class='tabs border-active'>
                     <ul>
-                        <li tabindex="0" *ngFor="let tab of tabs; let i = index;" class="hover-active" [ngClass]="{'background-active': tab.active}" (keyup.space)="selectTab(i)" (keyup.enter)="selectTab(i)" (click)="selectTab(i)">{{tab.name}}</li>
+                        <li
+                            #item
+                            tabindex="0"
+                            *ngFor="let tab of tabs; let i = index"
+                            class="border-active border-bottom-normal"
+                            [ngClass]="{active: tab.active}"
+                            (keyup.space)="selectTab(i)"
+                            (keyup.enter)="selectTab(i)"
+                            (click)="selectTab(i)">
+                            <span>{{tab.name}}</span>
+                        </li>
+                        <li *ngIf="_selectedIndex != -1" class="sticky background-normal border-active border-bottom-normal" [ngClass]="{active: !!'true', hidden: tabs[_selectedIndex].visible}" (click)="selectTab(_selectedIndex)">
+                            <span class="border-active">{{tabs[_selectedIndex].name}}</span>
+                        </li>
                     </ul>
+                    <div class="hider background-normal"></div>
                 </div>
             </div>
-        </div>
-        <div class='sme-focus-zone'>
+            <div class='menu-btn color-active background-normal' #menuBtn (click)="showMenu(true)"><span class="border-active hover-active color-normal" [class.background-active]="_menuOn"><i class="fa fa-ellipsis-h"></i></span></div>
+            <div class='menu border-active background-normal' [hidden]="!_menuOn">
+                <ul>
+                    <li tabindex="0" *ngFor="let tab of tabs; let i = index;" class="hover-active" [ngClass]="{'background-active': tab.active}" (keyup.space)="selectTab(i)" (keyup.enter)="selectTab(i)" (click)="selectTab(i)">{{tab.name}}</li>
+                </ul>
+            </div>
             <ng-content></ng-content>
         </div>
     `,
@@ -323,10 +317,6 @@ export class TabsComponent implements OnDestroy, AfterViewInit {
         if (diff < 0) {
             this.tabs[this._selectedIndex].visible = false;
         }
-    }
-    
-    private isWAC() {
-        return IsWAC;
     }
 }
 


### PR DESCRIPTION
This is to fix the label alignment issue of https://github.com/microsoft/IIS.WebManager/issues/366.

I have also fixed the usability issue by the sme-focus-zone in tab UI such as switching tab key and arrow key frequently. Now, we supports only arrow keys to get rid of the confusion.