### PR TITLE
Added the right padding for vtab-content

### DIFF
--- a/src/app/common/vtabs.component.ts
+++ b/src/app/common/vtabs.component.ts
@@ -274,6 +274,7 @@ span:focus {
 }
 
 .vtab-content {
+    padding-right: 20px;
     padding-left: 20px;
 }
 


### PR DESCRIPTION
There was a regression issue (UI truncation) because there is no right padding of each feature page.
