### PR TITLE
Make the project build for WAC

### DIFF
--- a/src/app/environments/environment.ts
+++ b/src/app/environments/environment.ts
@@ -1,2 +1,2 @@
-export const IsProduction = false;
-export const IsWAC = false;
+export const IsProduction = true;
+export const IsWAC = true;

--- a/src/app/main/app-routing.module.site.ts
+++ b/src/app/main/app-routing.module.site.ts
@@ -3,24 +3,17 @@ import { RouterModule } from "@angular/router";
 import { GetComponent } from "./get.component";
 import { ConnectComponent } from "connect/connect.component";
 import { NotFound } from "common/notfound.component";
-import { WACIdleComponent } from "runtime/wac/components/wac-idle.component";
-import { InstallComponent } from "runtime/wac/components/install.component";
 import { WebServerRoute } from "./settings";
 
 @NgModule({
   imports: [
     RouterModule.forRoot([
-        // routes for WAC only
-        { path: "idle", component: WACIdleComponent },
-        { path: "install", component: InstallComponent },
-        { path: "wac", loadChildren: "../runtime/wac/components/wac.module#WACModule" },
-
         // common routes
         { path: "", redirectTo: WebServerRoute, pathMatch: "full" },
         { path: "get", component: GetComponent },
         { path: "connect", component: ConnectComponent },
         { path: "settings", loadChildren: "../settings/settings.module#SettingsModule" },
-        { path: "webserver", loadChildren: "../webserver/webserver.module#WebServerModule" },
+        { path: WebServerRoute, loadChildren: "../webserver/webserver.module#WebServerModule" },
         { path: "**", component: NotFound },
     ],
         {

--- a/src/app/main/app.addon.site.ts
+++ b/src/app/main/app.addon.site.ts
@@ -1,0 +1,13 @@
+import { HttpImpl } from "common/http-impl";
+import { SiteRuntime } from "runtime/runtime";
+import { HttpModule } from "@angular/http";
+import { Provider } from "@angular/core";
+
+export const ModulesAddon: any[] = [
+    HttpModule,
+];
+
+export const ProvidersAddon: Provider[] = [
+    { provide: "Http", useClass: HttpImpl },
+    { provide: "Runtime", useClass: SiteRuntime },
+];

--- a/src/app/main/app.addon.ts
+++ b/src/app/main/app.addon.ts
@@ -1,13 +1,35 @@
-import { HttpImpl } from "common/http-impl";
-import { SiteRuntime } from "runtime/runtime";
-import { HttpModule } from "@angular/http";
-import { Provider } from "@angular/core";
+import { Provider, ErrorHandler } from "@angular/core";
+import {
+    ResourceService,
+    IdleModule,
+    CoreServiceModule,
+    GuidedPanelModule,
+    LoadingWheelModule,
+    IconModule,
+    SmeUxModule,
+} from "@microsoft/windows-admin-center-sdk/angular";
+import { PowershellService } from "runtime/wac/services/powershell-service";
+import { WACInfo, WACRuntime } from "runtime/runtime.wac";
+import { LocalHttpClient } from "runtime/wac/services/local-http-client";
+import { CommonModule } from "@angular/common";
+import { WACModule } from "runtime/wac/components/wac.module";
 
 export const ModulesAddon: any[] = [
-    HttpModule,
+    CommonModule,
+    IdleModule,
+    WACModule,
+    SmeUxModule,
+    IconModule,
+    LoadingWheelModule,
+    GuidedPanelModule,
+    CoreServiceModule,
 ];
 
 export const ProvidersAddon: Provider[] = [
-    { provide: "Http", useClass: HttpImpl },
-    { provide: "Runtime", useClass: SiteRuntime },
+    ResourceService,
+    { provide: ErrorHandler, useClass: ErrorHandler },
+    { provide: "Powershell", useClass: PowershellService },
+    { provide: "WACInfo", useClass: WACInfo },
+    { provide: "Http", useClass: LocalHttpClient },
+    { provide: "Runtime", useClass: WACRuntime },
 ];

--- a/src/app/main/bootstrap.site.ts
+++ b/src/app/main/bootstrap.site.ts
@@ -1,0 +1,3 @@
+export function preload(): Promise<void> {
+    return Promise.resolve();
+}

--- a/src/app/main/bootstrap.ts
+++ b/src/app/main/bootstrap.ts
@@ -1,3 +1,20 @@
+import { CoreEnvironment } from "@microsoft/windows-admin-center-sdk/core";
+import { PowerShellScripts } from "generated/powershell-scripts";
+import { IsProduction } from "environments/environment";
+
 export function preload(): Promise<void> {
-    return Promise.resolve();
+    // initialize SME module environment with localization settings.
+    return CoreEnvironment.initialize(
+    {
+        name: "msft.iis.iis-management",
+        powerShellModuleName: PowerShellScripts.module,
+        isProduction: IsProduction,
+        shellOrigin: '*',
+    },
+    {
+        resourcesPath: 'assets/strings',
+    },
+    {
+        disableStyleInjection: true,
+    });
 }


### PR DESCRIPTION
The project should be built for WAC when --env=wac is used with build.ps1. But it doesn't work. I don't see any code in the build process that handles --env=wac. After inspecting the code, I renamed the following files 
environment.ts is from environment.wac.prod.ts
app.addon.ts is from app.addon.wac.ts. The original file is saved app.addon.site.ts
app-routing.module.ts is from app-routing.module.wac.ts. The original file is saved as app-routing.module.site.ts
bootstrap.ts is from bootstrap.wac.ts. The original file is saved as bootstrap.site.ts.

In the future, if we want the project to work as standalone web application, we need to fix the build process to copy the files according to the --env switch