### PR TITLE
Fix build for WAC. The default flavor is wac now

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,7 @@ function ToPassThroughArgs($inputArgs) {
 }
 
 $purge = $args | Where-Object { $_ -like "--purge" }
-$env = $args | Where-Object { $_ -like "--env" -or $_ -like "--configuration"-or $_  -like "-c"}
+$buildEnv = $args | Where-Object { $_.ToLower().startsWith("--env=")}
 $pack = $args | Where-Object { $_ -like "--pack" }
 $serve = $args | Where-Object { $_ -like "--serve" }
 $version = $args | Where-Object { $_.ToLower().startsWith("--version=") }
@@ -46,9 +46,12 @@ elseif ($pack)
    throw "--version=xxx.xxx is required if --pack is provided"
 }
 
-if(!$env)
+if($buildEnv)
 {
-    $env = "-c=wac"
+      $buildEnv = "-c=" + $buildEnv.split("=")[1]
+}
+else {
+    $buildEnv = "-c=wac"
 }
 
 if (!(Get-Command "npm" -ErrorAction SilentlyContinue)) {
@@ -112,7 +115,7 @@ try {
     }
 
     Write-Host "Building project..."
-    gulp build $buildArgs $env
+    gulp build $buildArgs $buildEnv
 
     Write-Host ("OutputDirectory: " + (Resolve-Path "..\dist").Path)
     if ($pack) {

--- a/build.ps1
+++ b/build.ps1
@@ -48,7 +48,11 @@ elseif ($pack)
 
 if($buildEnv)
 {
-      $buildEnv = "-c=" + $buildEnv.split("=")[1]
+    $buildEnv = "-c=" + $buildEnv.split("=")[1]
+    if ($buildEnv -ne "-c=wac")
+    {
+        $buildEnv = "" # se blank for non-wac build for now
+    }
 }
 else {
     $buildEnv = "-c=wac"

--- a/build.ps1
+++ b/build.ps1
@@ -112,6 +112,7 @@ try {
     if (ShouldNPMInstall) {
         Write-Host "Installing dependencies..."
         npm install 
+        npm audit fix --legacy-peer-deps
     }
 
     Write-Host "Building project..."

--- a/build.ps1
+++ b/build.ps1
@@ -25,10 +25,14 @@ function ShouldNPMInstall {
 }
 
 function ToPassThroughArgs($inputArgs) {
-    return $inputArgs | Where-Object { $_ -notlike "--purge" -and $_ -notlike "--pack" -and $_ -notlike "--serve" -and -not ($_.startsWith("--version="))}
+    return $inputArgs | Where-Object { $_ -notlike "--purge" -and $_ -notlike "--pack" `
+    -and $_ -notlike "--serve" -and -not ($_.startsWith("--version=")) `
+    -and -not ($_.startsWith("--env=")) -and -not ($_.startsWith("--configuration=")) `
+    -and -not ($_.startsWith("-c="))}
 }
 
 $purge = $args | Where-Object { $_ -like "--purge" }
+$env = $args | Where-Object { $_ -like "--env" -or $_ -like "--configuration"-or $_  -like "-c"}
 $pack = $args | Where-Object { $_ -like "--pack" }
 $serve = $args | Where-Object { $_ -like "--serve" }
 $version = $args | Where-Object { $_.ToLower().startsWith("--version=") }
@@ -36,6 +40,15 @@ if ($version) {
     # Example: --version=0.1.$(Build.BuildNumber)
     Write-Host ($version)
     $version = $version.split("=")[1]
+}
+elseif ($pack)
+{    
+   throw "--version=xxx.xxx is required if --pack is provided"
+}
+
+if(!$env)
+{
+    $env = "-c=wac"
 }
 
 if (!(Get-Command "npm" -ErrorAction SilentlyContinue)) {
@@ -48,7 +61,7 @@ if ($purge -and !(Get-Command "git" -ErrorAction SilentlyContinue)) {
 
 if ($pack) {
     if (!(Get-Command "nuget" -ErrorAction SilentlyContinue)) {
-        throw """--pack"" operation requires nugetin PATH"
+        throw """--pack"" operation requires nuget.exe in PATH"
     }
 
     $outputHashingTag = "--output-hashing"
@@ -85,8 +98,8 @@ try {
     $allDependencies = Get-Content "package.json" | ConvertFrom-Json
 
     foreach($pkg in $buildTools) {
-        $version = $allDependencies.devDependencies."$pkg"
-        $pkgVersion = "${pkg}@${version}"
+        $versionFile = $allDependencies.devDependencies."$pkg"
+        $pkgVersion = "${pkg}@${versionFile}"
         Write-Verbose "Dev dependency found: ${pkgVersion}"
         if (!((npm list -g $pkgVersion) | Where-Object { $_ -match "$pkgVersion\s*$" })) {
             npm install -g $pkgVersion
@@ -95,11 +108,11 @@ try {
 
     if (ShouldNPMInstall) {
         Write-Host "Installing dependencies..."
-        npm install
+        npm install 
     }
 
     Write-Host "Building project..."
-    gulp build $buildArgs
+    gulp build $buildArgs $env
 
     Write-Host ("OutputDirectory: " + (Resolve-Path "..\dist").Path)
     if ($pack) {

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "@angular/common": "7.1.1",
-    "@angular/core": "11.0.5",
+    "@angular/core": "7.1.1",
     "@angular/forms": "7.1.1",
     "@angular/http": "7.1.1",
     "@angular/platform-browser": "7.1.1",
@@ -61,7 +61,7 @@
     "gulp": "4.0.0",
     "gulp-autoprefixer": "6.0.0",
     "gulp-batch": "1.0.5",
-    "gulp-clean": "0.3.2",
+    "gulp-clean": "0.4.0",
     "gulp-cli": "2.1.0",
     "gulp-inline-ng2-template": "5.0.1",
     "gulp-jasmine": "4.0.0",
@@ -75,7 +75,7 @@
     "jasmine-reporters": "2.2.1",
     "jasmine-terminal-reporter": "1.0.3",
     "jsdom": "16.5.0",
-    "karma": "6.3.16",
+    "karma": "4.1.0",
     "karma-chrome-launcher": "2.1.1",
     "karma-cli": "1.0.1",
     "karma-coverage-istanbul-reporter": "1.2.1",
@@ -84,10 +84,10 @@
     "karma-remap-istanbul": "0.6.0",
     "ping": "0.2.2",
     "primeng": "4.1.0",
-    "protractor": "5.4.2",
+    "protractor": "5.4.4",
     "readline-sync": "1.4.9",
     "run-sequence": "2.2.0",
-    "rxjs-tslint": "0.1.5",
+    "rxjs-tslint": "0.1.8",
     "rxjs-tslint-rules": "4.10.0",
     "selenium-webdriver": "3.6.0",
     "signalr": "2.3.0",
@@ -103,6 +103,7 @@
     "tsutils": "3.10.0",
     "typescript": "3.1.6",
     "vinyl": "2.2.0",
-    "winstrap": "0.5.12"
+    "winstrap": "0.5.12",
+    "xmlhttprequest-ssl": "1.6.3"
   }
 }


### PR DESCRIPTION
--env=wac was required to build the project for WAC, but it should never have worked since it is not passed to "gulp build"

Updated some packages with security issues. Changed angular/core back to 7.1.1. There will be too many changes if we update the angular/core to the newest release.

There are still security warnings. But they are all about packages in development time, no security issues for runtime packages. Due to the very complicated dependency structure, it is too much work to eliminate all security warnings in development time.